### PR TITLE
Add backend API tests for authentication and notes viewsets

### DIFF
--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class RegisterViewTests(APITestCase):
+    def test_register_requires_username_and_password(self):
+        url = reverse("register")
+
+        response = self.client.post(url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {"error": "Username and password required."})
+
+    def test_register_rejects_duplicate_username(self):
+        User.objects.create_user(username="existing", password="pass1234")
+        url = reverse("register")
+
+        response = self.client.post(
+            url,
+            {"username": "existing", "password": "new-password"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {"error": "Username already exists."})
+
+    def test_register_creates_user(self):
+        url = reverse("register")
+
+        response = self.client.post(
+            url,
+            {"username": "new-user", "password": "password123"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data, {"message": "User created successfully."})
+        self.assertTrue(User.objects.filter(username="new-user").exists())

--- a/backend/notes/tests.py
+++ b/backend/notes/tests.py
@@ -1,0 +1,88 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from .models import Workspace, TodoList, Note
+
+
+class WorkspaceViewSetTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pass1234")
+        self.client.force_authenticate(self.user)
+
+    def test_create_workspace_sets_owner_and_creator(self):
+        url = reverse("workspace-list")
+
+        response = self.client.post(
+            url,
+            {"name": "Project", "description": "Notes"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        workspace = Workspace.objects.get(name="Project")
+        self.assertEqual(workspace.owner, self.user)
+        self.assertEqual(workspace.created_by, self.user)
+
+
+class TodoListViewSetTests(APITestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="pass1234")
+        self.other_user = User.objects.create_user(
+            username="other", password="pass1234"
+        )
+        self.workspace = Workspace.objects.create(
+            name="Workspace",
+            description="Main",
+            owner=self.owner,
+            created_by=self.owner,
+        )
+        self.client.force_authenticate(self.other_user)
+
+    def test_create_todolist_requires_workspace_access(self):
+        url = reverse("todolist-list")
+
+        response = self.client.post(
+            url,
+            {"name": "Todo", "description": "Work", "workspace": self.workspace.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(TodoList.objects.filter(name="Todo").exists())
+
+
+class NoteViewSetTests(APITestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="pass1234")
+        self.collaborator = User.objects.create_user(
+            username="collab", password="pass1234"
+        )
+        self.workspace = Workspace.objects.create(
+            name="Workspace",
+            description="Main",
+            owner=self.owner,
+            created_by=self.owner,
+        )
+        self.todo_list = TodoList.objects.create(
+            name="Todo",
+            description="Work",
+            workspace=self.workspace,
+            owner=self.owner,
+            created_by=self.owner,
+        )
+        self.todo_list.collaborators.add(self.collaborator)
+        self.client.force_authenticate(self.collaborator)
+
+    def test_create_note_allows_collaborator(self):
+        url = reverse("note-list")
+
+        response = self.client.post(
+            url,
+            {"note": "Task", "description": "Do it", "todo_list": self.todo_list.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Note.objects.filter(note="Task").exists())


### PR DESCRIPTION
### Motivation
- Improve test coverage for the backend API by exercising the authentication registration flow and notes-related access control and ownership behaviors.
- Prevent regressions around who can create workspaces, todo-lists, and notes by codifying expected authorization rules.

### Description
- Added `backend/authentication/tests.py` implementing `RegisterViewTests` that verify required fields, duplicate username rejection, and successful user creation.
- Added `backend/notes/tests.py` implementing `WorkspaceViewSetTests`, `TodoListViewSetTests`, and `NoteViewSetTests` to verify owner/creator assignment, workspace access control (403), and collaborator note creation.
- Tests use Django REST Framework's `APITestCase`, `force_authenticate`, and reverse URL names such as `register`, `workspace-list`, `todolist-list`, and `note-list`.

### Testing
- Ran `python manage.py test` in the `backend` directory as an automated test run and it failed due to a missing dependency with the error `ModuleNotFoundError: No module named 'django'`.
- No other automated test runs were executed successfully in this environment due to the missing Django installation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965acecbafc8333ab97bab0bac50fa8)