### PR TITLE
Rename API helpers to BackendClient and update imports/tests

### DIFF
--- a/frontend/src/components/MyDrawer.js
+++ b/frontend/src/components/MyDrawer.js
@@ -19,7 +19,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import Collapse from '@mui/material/Collapse';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import { apiFetch } from '../services/client';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  fetchWorkspace as fetchWorkspaceApi,
+  fetchWorkspaces as fetchWorkspacesApi,
+  updateWorkspace,
+} from '../services/BackendClient';
 
 export default function MyDrawer({
   open,
@@ -38,9 +44,7 @@ export default function MyDrawer({
   const fetchWorkspaceName = useCallback(async () => {
     if (!workspaceId) return '';
     try {
-      const response = await apiFetch(`/api/workspaces/${workspaceId}/`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchWorkspaceApi(workspaceId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const workspaceData = await response.json();
       return workspaceData?.name ?? '';
@@ -68,9 +72,7 @@ export default function MyDrawer({
   const fetchWorkspaces = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await apiFetch('/api/workspaces/', {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchWorkspacesApi(token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       setWorkspaces(data);
@@ -95,17 +97,13 @@ export default function MyDrawer({
     setError(null);
 
     try {
-      const response = await apiFetch('/api/workspaces/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({
+      const response = await createWorkspace(
+        {
           name: newWorkspaceName,
           description: '',
-        }),
-      });
+        },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -152,14 +150,11 @@ export default function MyDrawer({
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/workspaces/${editingWorkspaceId}/`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({ name: editWorkspaceName }),
-      });
+      const response = await updateWorkspace(
+        editingWorkspaceId,
+        { name: editWorkspaceName },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -185,13 +180,7 @@ export default function MyDrawer({
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/workspaces/${id}/`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-      });
+      const response = await deleteWorkspace(id, token);
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/pages/authentication/Login.js
+++ b/frontend/src/pages/authentication/Login.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { TextField, Button, Typography, Box, Paper, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { apiFetch } from '../../services/client';
+import { fetchWorkspaces as fetchWorkspacesApi, login } from '../../services/BackendClient';
 
 export default function Login({ showSnackbar }) {
   // Basics
@@ -14,9 +14,7 @@ export default function Login({ showSnackbar }) {
   const fetchWorkspaces = useCallback(
     async (token, showError) => {
       try {
-        const response = await apiFetch('/api/workspaces/', {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        });
+        const response = await fetchWorkspacesApi(token);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
         return data;
@@ -38,13 +36,7 @@ export default function Login({ showSnackbar }) {
   // Login function
   const handleLogin = async () => {
     try {
-      const response = await apiFetch('/auth/login/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ username, password }),
-      });
+      const response = await login({ username, password });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/pages/authentication/Login.test.js
+++ b/frontend/src/pages/authentication/Login.test.js
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../test-utils';
 import Login from './Login';
-import { apiFetch } from '../../services/client';
+import { fetchWorkspaces, login } from '../../services/BackendClient';
 import { useNavigate } from 'react-router-dom';
 
 jest.mock('react-router-dom', () => ({
@@ -10,11 +10,17 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
 }));
 
-jest.mock('../../services/client', () => ({
-  apiFetch: jest.fn(() =>
+jest.mock('../../services/BackendClient', () => ({
+  fetchWorkspaces: jest.fn(() =>
     Promise.resolve({
       ok: true,
       json: async () => [],
+    }),
+  ),
+  login: jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     }),
   ),
 }));
@@ -37,20 +43,18 @@ describe('Login', () => {
   });
 
   test('when login succeeds and workspaces exist, it navigates to the first workspace', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [{ id: 7 }, { id: 3 }, { id: 12 }],
-        });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: 7 }, { id: 3 }, { id: 12 }],
+      });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     });
 
     renderWithProviders(<Login showSnackbar={jest.fn()} />);
@@ -67,17 +71,13 @@ describe('Login', () => {
   test('when login succeeds and no workspaces exist, it navigates home', async () => {
     // Component calls /api/workspaces/ on mount, so we must handle it.
     // Then when we login, /auth/login/ should succeed.
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     });
 
     renderWithProviders(<Login showSnackbar={jest.fn()} />);
@@ -91,13 +91,10 @@ describe('Login', () => {
 
     // Confirm the login request happened with the creds we typed
     await waitFor(() => {
-      expect(apiFetch).toHaveBeenCalledWith(
-        '/auth/login/',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({ username: 'test_username', password: 'test_password' }),
-        }),
-      );
+      expect(login).toHaveBeenCalledWith({
+        username: 'test_username',
+        password: 'test_password',
+      });
     });
 
     // Confirm we navigated to the main page when no workspaces are returned
@@ -109,17 +106,13 @@ describe('Login', () => {
   test('when login succeeds, it stores access/refresh tokens', async () => {
     // Component calls /api/workspaces/ on mount, so we must handle it.
     // Then when we login, /auth/login/ should succeed.
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'test_access_token', refresh: 'test_refresh_token' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'test_access_token', refresh: 'test_refresh_token' }),
     });
 
     const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
@@ -146,17 +139,13 @@ describe('Login', () => {
   });
 
   test('when login succeeds, it shows a success snackbar', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     });
 
     const showSnackbar = jest.fn();
@@ -173,17 +162,15 @@ describe('Login', () => {
   });
 
   test('when workspace fetch fails after login, it navigates home', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: false, status: 500, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     });
 
     renderWithProviders(<Login showSnackbar={jest.fn()} />);
@@ -198,17 +185,15 @@ describe('Login', () => {
   });
 
   test('when workspace fetch fails after login, it shows an error snackbar', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: false, status: 500, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
+    login.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access: 'ACCESS', refresh: 'REFRESH' }),
     });
 
     const showSnackbar = jest.fn();
@@ -227,18 +212,14 @@ describe('Login', () => {
   test('when login fails, it does not navigate', async () => {
     // Component calls /api/workspaces/ on mount, so we must handle it.
     // Then when we login, /auth/login/ should succeed.
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: false,
-          status: 401,
-          json: async () => ({ detail: 'Invalid credentials' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'Invalid credentials' }),
     });
 
     // Login.js logs the auth error; silence it here to avoid noisy test output.
@@ -264,18 +245,14 @@ describe('Login', () => {
   });
 
   test('when login fails, it does not store tokens', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: false,
-          status: 401,
-          json: async () => ({ detail: 'Invalid credentials' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'Invalid credentials' }),
     });
 
     const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
@@ -298,18 +275,14 @@ describe('Login', () => {
   });
 
   test('when login fails, it shows an error snackbar', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.resolve({
-          ok: false,
-          status: 401,
-          json: async () => ({ detail: 'Invalid credentials' }),
-        });
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    login.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: 'Invalid credentials' }),
     });
 
     const showSnackbar = jest.fn();
@@ -331,15 +304,11 @@ describe('Login', () => {
   });
 
   test('when login fails due to a network error, it does not navigate', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.reject(new TypeError('NetworkError when attempting to fetch resource.'));
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
     });
+    login.mockRejectedValue(new TypeError('NetworkError when attempting to fetch resource.'));
 
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -359,15 +328,11 @@ describe('Login', () => {
   });
 
   test('when login fails due to a network error, it does not store tokens', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.reject(new TypeError('NetworkError when attempting to fetch resource.'));
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
     });
+    login.mockRejectedValue(new TypeError('NetworkError when attempting to fetch resource.'));
 
     const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -389,15 +354,11 @@ describe('Login', () => {
   });
 
   test('when login fails due to a network error, it shows a network error snackbar', async () => {
-    apiFetch.mockImplementation((url) => {
-      if (url === '/api/workspaces/') {
-        return Promise.resolve({ ok: true, json: async () => [] });
-      }
-      if (url === '/auth/login/') {
-        return Promise.reject(new TypeError('NetworkError when attempting to fetch resource.'));
-      }
-      throw new Error(`Unhandled apiFetch call: ${url}`);
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [],
     });
+    login.mockRejectedValue(new TypeError('NetworkError when attempting to fetch resource.'));
 
     const showSnackbar = jest.fn();
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/frontend/src/pages/notes/Notes.js
+++ b/frontend/src/pages/notes/Notes.js
@@ -14,7 +14,13 @@ import {
 import { Add, Close, MoreVert } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { useParams } from 'react-router-dom';
-import { apiFetch } from '../../services/client';
+import {
+  createNote,
+  deleteNote,
+  fetchNotes as fetchNotesApi,
+  fetchTodoList as fetchTodoListApi,
+  updateNote,
+} from '../../services/BackendClient';
 
 export default function Notes({ setAppBarHeader }) {
   // Pull Todolist ID
@@ -29,9 +35,7 @@ export default function Notes({ setAppBarHeader }) {
   const fetchNotes = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await apiFetch(`/api/notes/?todo_list=${todoListId}`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchNotesApi(todoListId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       setLists(data);
@@ -47,9 +51,7 @@ export default function Notes({ setAppBarHeader }) {
   const fetchTodoListName = useCallback(async () => {
     if (!todoListId) return;
     try {
-      const response = await apiFetch(`/api/todolists/${todoListId}/`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchTodoListApi(todoListId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const todoListData = await response.json();
       setAppBarHeader(todoListData?.name ?? '');
@@ -89,18 +91,15 @@ export default function Notes({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/notes/?todo_list=${todoListId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({
+      const response = await createNote(
+        todoListId,
+        {
           note: newNote,
           todo_list: todoListId,
           description: '',
-        }),
-      });
+        },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -129,14 +128,7 @@ export default function Notes({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/notes/${editingNoteId}/`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({ note: editNote }),
-      });
+      const response = await updateNote(editingNoteId, { note: editNote }, token);
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -159,13 +151,7 @@ export default function Notes({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/notes/${id}/`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-      });
+      const response = await deleteNote(id, token);
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/pages/notes/TodoLists.js
+++ b/frontend/src/pages/notes/TodoLists.js
@@ -15,7 +15,12 @@ import { Add, Close, MoreVert } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
-import { apiFetch } from '../../services/client';
+import {
+  createTodoList,
+  deleteTodoList,
+  fetchTodoLists as fetchTodoListsApi,
+  updateTodoList,
+} from '../../services/BackendClient';
 
 export default function TodoLists({ setAppBarHeader }) {
   // Misc
@@ -38,9 +43,7 @@ export default function TodoLists({ setAppBarHeader }) {
   const fetchTodoLists = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchTodoListsApi(workspaceId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       setLists(data);
@@ -83,18 +86,15 @@ export default function TodoLists({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({
+      const response = await createTodoList(
+        workspaceId,
+        {
           name: newTodoListName,
           workspace: workspaceId,
           description: '',
-        }),
-      });
+        },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -123,14 +123,11 @@ export default function TodoLists({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/todolists/${editingTodoListId}/`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({ name: editTodoListName }),
-      });
+      const response = await updateTodoList(
+        editingTodoListId,
+        { name: editTodoListName },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -153,13 +150,7 @@ export default function TodoLists({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/todolists/${id}/`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-      });
+      const response = await deleteTodoList(id, token);
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/pages/notes/Workspaces.js
+++ b/frontend/src/pages/notes/Workspaces.js
@@ -14,7 +14,12 @@ import {
 import { Add, Close, MoreVert } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import { useNavigate } from 'react-router-dom';
-import { apiFetch } from '../../services/client';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  fetchWorkspaces as fetchWorkspacesApi,
+  updateWorkspace,
+} from '../../services/BackendClient';
 
 export default function Workspaces({ setAppBarHeader }) {
   // Misc
@@ -29,9 +34,7 @@ export default function Workspaces({ setAppBarHeader }) {
   const fetchWorkspaces = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await apiFetch('/api/workspaces/', {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
+      const response = await fetchWorkspacesApi(token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       setLists(data);
@@ -73,17 +76,13 @@ export default function Workspaces({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch('/api/workspaces/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({
+      const response = await createWorkspace(
+        {
           name: newWorkspaceName,
           description: '',
-        }),
-      });
+        },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -112,14 +111,11 @@ export default function Workspaces({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/workspaces/${editingWorkspaceId}/`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-        body: JSON.stringify({ name: editWorkspaceName }),
-      });
+      const response = await updateWorkspace(
+        editingWorkspaceId,
+        { name: editWorkspaceName },
+        token,
+      );
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -144,13 +140,7 @@ export default function Workspaces({ setAppBarHeader }) {
     setError(null);
 
     try {
-      const response = await apiFetch(`/api/workspaces/${id}/`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token && { Authorization: `Bearer ${token}` }),
-        },
-      });
+      const response = await deleteWorkspace(id, token);
 
       // Pessimistic Local Merge
       if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/services/BackendClient.js
+++ b/frontend/src/services/BackendClient.js
@@ -1,0 +1,99 @@
+import { apiFetch } from './client';
+
+const authHeader = (token) => (token ? { Authorization: `Bearer ${token}` } : {});
+const jsonHeaders = (token) => ({
+  'Content-Type': 'application/json',
+  ...authHeader(token),
+});
+
+export const login = ({ username, password }) =>
+  apiFetch('/auth/login/', {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ username, password }),
+  });
+
+export const fetchWorkspaces = (token) =>
+  apiFetch('/api/workspaces/', {
+    headers: authHeader(token),
+  });
+
+export const fetchWorkspace = (workspaceId, token) =>
+  apiFetch(`/api/workspaces/${workspaceId}/`, {
+    headers: authHeader(token),
+  });
+
+export const createWorkspace = (payload, token) =>
+  apiFetch('/api/workspaces/', {
+    method: 'POST',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const updateWorkspace = (workspaceId, payload, token) =>
+  apiFetch(`/api/workspaces/${workspaceId}/`, {
+    method: 'PATCH',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const deleteWorkspace = (workspaceId, token) =>
+  apiFetch(`/api/workspaces/${workspaceId}/`, {
+    method: 'DELETE',
+    headers: jsonHeaders(token),
+  });
+
+export const fetchTodoLists = (workspaceId, token) =>
+  apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
+    headers: authHeader(token),
+  });
+
+export const fetchTodoList = (todoListId, token) =>
+  apiFetch(`/api/todolists/${todoListId}/`, {
+    headers: authHeader(token),
+  });
+
+export const createTodoList = (workspaceId, payload, token) =>
+  apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
+    method: 'POST',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const updateTodoList = (todoListId, payload, token) =>
+  apiFetch(`/api/todolists/${todoListId}/`, {
+    method: 'PATCH',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const deleteTodoList = (todoListId, token) =>
+  apiFetch(`/api/todolists/${todoListId}/`, {
+    method: 'DELETE',
+    headers: jsonHeaders(token),
+  });
+
+export const fetchNotes = (todoListId, token) =>
+  apiFetch(`/api/notes/?todo_list=${todoListId}`, {
+    headers: authHeader(token),
+  });
+
+export const createNote = (todoListId, payload, token) =>
+  apiFetch(`/api/notes/?todo_list=${todoListId}`, {
+    method: 'POST',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const updateNote = (noteId, payload, token) =>
+  apiFetch(`/api/notes/${noteId}/`, {
+    method: 'PATCH',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+export const deleteNote = (noteId, token) =>
+  apiFetch(`/api/notes/${noteId}/`, {
+    method: 'DELETE',
+    headers: jsonHeaders(token),
+  });


### PR DESCRIPTION
## 📌 Summary (what & why):
- Centralizes all frontend calls to the Django backend into a new `BackendClient` service, replacing scattered direct `apiFetch` usage.
- Refactors workspace, todo list, note, and login flows to use higher-level helper functions (e.g., `createWorkspace`, `fetchTodoLists`, `login`) for clearer intent and less duplication.
- Updates login tests to mock and assert against the new `BackendClient` API instead of low-level `apiFetch`, aligning tests with the new abstraction.

## 📂 Scope (what areas are affected):
- Frontend service layer:
  - New `frontend/src/services/BackendClient.js` encapsulating REST calls for auth, workspaces, todo lists, and notes.
- Frontend UI components:
  - Drawer workspace selector (`MyDrawer`)
  - Authentication login page (`Login`)
  - Notes and todo list pages (`Notes`, `TodoLists`, `Workspaces`)
- Frontend tests:
  - `Login.test.js` now mocks `BackendClient` functions.

## 🔄 Behavior Changes (user-visible or API-visible):
- Intended behavior is unchanged:
  - Login, workspace selection/creation/rename/delete, todo list and note CRUD should function as before.
- Any subtle behavior differences would only come from the new abstraction layer, but the underlying endpoints, methods, and payloads remain the same.

## ⚠️ Risk & Impact (what could break / who is affected):
- All authenticated flows that hit the backend (login, workspace/todo list/note CRUD) depend on `BackendClient`; a bug in headers, URLs, or payloads could break large portions of the app.
- Token handling is now centralized via helper functions; mistakes in `authHeader` / `jsonHeaders` could cause authorization failures.
- Tests currently updated only for `Login`; other components rely on runtime behavior and could hide regressions if not covered elsewhere.

## 🔎 Suggested Verification (quick checks):
- Manually:
  - Log in with valid and invalid credentials; confirm navigation, token storage, and snackbars still behave as before.
  - From a fresh login, verify:
    - Workspaces list loads; create, rename, and delete a workspace.
    - Within a workspace, todo lists load; create, rename, and delete a todo list.
    - Within a todo list, notes load; create, edit, and delete a note.
  - Confirm that actions requiring auth fail appropriately when logged out or with an invalid token.
- Automated:
  - Run frontend test suite, especially `Login.test.js`, to ensure mocks and expectations are correct.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add unit tests for `BackendClient` itself (e.g., verifying correct URLs, methods, and headers for each function).
- Gradually migrate any remaining direct `apiFetch` usages to `BackendClient` for consistency.
- Consider grouping `BackendClient` exports by domain (auth, workspaces, todos, notes) or using TypeScript types to make the API more self-documenting.