### PR TITLE
empty

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -9,6 +9,8 @@ on:
       - "backend/**"
       - ".github/**/*.yml"
       - ".github/**/*.yaml"
+      - ".github/*.yml"
+      - ".github/*.yaml"
 
 concurrency:
   group: lint-${{ github.ref }}

--- a/frontend/src/components/MyAppBar.js
+++ b/frontend/src/components/MyAppBar.js
@@ -15,6 +15,10 @@ export default function MyAppBar({ appBarHeader, setDrawerOpen }) {
     goBackToParent(location.pathname, navigate);
   };
 
+
+
+
+  
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar


### PR DESCRIPTION
## 📌 Summary (what & why):
- Expands the linting GitHub Action trigger so that changes to workflow files directly under `.github/` (not just in subdirectories) will also run lint checks. This helps ensure CI consistency when core workflow files are edited.
- Minor, likely unintentional whitespace-only change in the `MyAppBar` React component; no functional logic added or removed.

## 📂 Scope (what areas are affected):
- CI / GitHub Actions:
  - Lint workflow trigger configuration.
- Frontend:
  - `MyAppBar` component (cosmetic whitespace only).

## 🔄 Behavior Changes (user-visible or API-visible):
- No user-facing or API behavior changes.
- CI behavior: lint workflow will now run on more `.github/*.yml` and `.github/*.yaml` changes.

## ⚠️ Risk & Impact (what could break / who is affected):
- Very low risk:
  - Developers may see lint jobs run more often when editing top-level `.github` workflow files.
  - No runtime impact on backend or frontend behavior.

## 🔎 Suggested Verification (quick checks):
- Push a test branch that modifies a top-level `.github/*.yml` or `.github/*.yaml` file and confirm the lint workflow is triggered.
- Quick smoke test of the frontend to ensure `MyAppBar` still renders as expected (mainly as a sanity check, since only whitespace changed).

## ➕ Follow-ups (nice-to-do, not required for merge):
- (none)