### PR TITLE
Added GitHub YAML linting with auto-formatting for `.github` YAML fil…

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: lint-${{ github.ref }}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Expands the lint workflow to also cover `.github` YAML files, ensuring GitHub Actions and related configs are consistently formatted and validated.
- Updates `actions/setup-node` and `actions/setup-python` to their latest major versions for frontend and backend lint jobs.
- Adds an auto-fix + auto-commit step for `.github` YAML formatting using Prettier, followed by YAML validation with `yamllint`.
- Allows the lint workflow to be run manually via `workflow_dispatch` instead of only on PRs that touch frontend/backend paths.

## 📂 Scope (what areas are affected):
- GitHub Actions CI configuration (`.github/workflows/lints.yaml`).
- Frontend lint job (Node setup action version).
- Backend lint job (Python setup action version).
- New lint job specifically for `.github` YAML files (GitHub Actions and other YAML configs under `.github/`).

## 🔄 Behavior Changes (user-visible or API-visible):
- Lint workflow can now be triggered manually from the GitHub Actions UI (`workflow_dispatch`).
- When `.github` YAML files change in a PR, a new job will:
  - Auto-format those YAML files with Prettier.
  - Auto-commit the formatting changes back to the PR branch using a `lint-bot` identity.
  - Run `yamllint` on `.github` to catch structural/style issues (with line-length checks disabled).
- Frontend/backend lint behavior remains the same, but uses newer setup actions under the hood.

## ⚠️ Risk & Impact (what could break / who is affected):
- Contributors modifying `.github` YAML will see automatic commits pushed to their branches, which could:
  - Surprise users not expecting CI to modify their branch.
  - Cause minor friction if they have local changes not in sync with the remote.
- Misconfiguration of the new YAML lint job (e.g., path patterns or auto-commit settings) could:
  - Fail the workflow unexpectedly.
  - Potentially format or commit unintended files if patterns are too broad (currently looks scoped to `.github/**/*.yml/.yaml`).
- Upgrading `setup-node` and `setup-python` actions is low risk but could surface new warnings or behavior changes from those actions.

## 🔎 Suggested Verification (quick checks):
- Open a test PR that modifies:
  - A `.github/workflows/*.yml` file and confirm:
    - `lint-github-yaml` runs.
    - Prettier formatting changes are auto-committed to the PR branch.
    - `yamllint` passes or reports expected issues.
  - Only frontend files and confirm only frontend lint runs.
  - Only backend files and confirm only backend lint runs.
- Trigger the workflow manually via `workflow_dispatch` and confirm all relevant lint jobs behave as expected.
- Verify that the auto-commit bot’s username/email and commit messages look acceptable in the project history.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Document in CONTRIBUTING or a short CI guide that `.github` YAML changes will be auto-formatted and auto-committed by CI.
- Consider whether auto-commit should be opt-in (e.g., only on specific branches) or replaced with a “check-only” mode plus a separate formatter script.
- Add a shared Prettier/yamllint config file (if not already present) to centralize YAML style rules.