### PR TITLE
Replaced the Dependabot auto-approval action with a GitHub API call t…

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -66,10 +66,17 @@ jobs:
 
       - name: Auto-approve Dependabot PR
         if: steps.checks.outputs.all_passed == 'true'
-        uses: peter-evans/approve-pull-request@v4
+        uses: actions/github-script@v7
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number,
+              event: 'APPROVE',
+            });
 
       - name: Enable auto-merge
         if: steps.checks.outputs.all_passed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Updated Dependabot config to run daily updates for npm, GitHub Actions, and Docker.
 - Renamed GitHub Actions workflow files to use plural names (`lints.yaml`, `pr_summaries.yaml`).
+- Replaced the Dependabot auto-approval action with a GitHub API call to avoid the missing action repo.
 
 ## 2026-01-18
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Replaced the Dependabot auto-approval GitHub Action with a direct GitHub API call via `actions/github-script` to avoid relying on a missing/removed third-party action repository.
- Standardized GitHub Actions workflows to use `actions/checkout@v4` instead of `@v6`, aligning with stable, supported versions.
- Documented the Dependabot auto-approval change in the changelog for traceability.

## 📂 Scope (what areas are affected):
- GitHub Actions workflows:
  - `dependabot_auto_merge.yml`
  - `lints.yaml`
  - `pr_summaries.yaml`
  - `tests.yaml`
- Project documentation:
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs that pass checks will still be auto-approved, but now via a GitHub API review created by `actions/github-script` instead of the `peter-evans/approve-pull-request` action.
- No functional changes to linting, PR summary, or test workflows other than using a different checkout action version.

## ⚠️ Risk & Impact (what could break / who is affected):
- If the GitHub Script step is misconfigured (e.g., context differences or permission issues), Dependabot PRs may stop being auto-approved or auto-merged.
- Any subtle behavioral differences between `actions/checkout@v6` and `@v4` could affect CI, though this is unlikely and mostly limited to how the repo is fetched in workflows.

## 🔎 Suggested Verification (quick checks):
- Open or re-run a Dependabot PR and confirm:
  - All checks pass.
  - The workflow posts an “Approved” review on the PR.
  - Auto-merge is still enabled as expected.
- Ensure standard PRs (non-Dependabot) are not auto-approved by this workflow.
- Confirm lint, test, and PR summary workflows still trigger and complete successfully on a normal PR.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add a small comment in the Dependabot workflow explaining why `actions/github-script` is preferred (missing third-party action, future-proofing).
- Periodically review all GitHub Actions versions (including `actions/setup-node`, `actions/setup-python`) for consistency and support status.