### PR TITLE
Replaced the Dependabot auto-approval action with a GitHub API call t…

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -66,10 +66,17 @@ jobs:
 
       - name: Auto-approve Dependabot PR
         if: steps.checks.outputs.all_passed == 'true'
-        uses: peter-evans/approve-pull-request@v4
+        uses: actions/github-script@v7
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number,
+              event: 'APPROVE',
+            });
 
       - name: Enable auto-merge
         if: steps.checks.outputs.all_passed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Updated Dependabot config to run daily updates for npm, GitHub Actions, and Docker.
 - Renamed GitHub Actions workflow files to use plural names (`lints.yaml`, `pr_summaries.yaml`).
+- Replaced the Dependabot auto-approval action with a GitHub API call to avoid the missing action repo.
 
 ## 2026-01-18
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Swapped the Dependabot auto-approval GitHub Action for a direct GitHub API call via `actions/github-script`, avoiding reliance on an external action repository that may be missing or unavailable.
- Updated the changelog to document this CI workflow change.
- Aligned the frontend dev dependency `eslint-config-prettier` back to version `9.1.2` (from `10.1.8`), likely to restore compatibility or stability in the linting toolchain.

## 📂 Scope (what areas are affected):
- GitHub Actions CI:
  - Dependabot auto-merge workflow (`dependabot_auto_merge.yml`).
- Project documentation:
  - `CHANGELOG.md`.
- Frontend tooling / developer experience:
  - `frontend/package.json` and `frontend/package-lock.json` (ESLint + Prettier config).

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct end-user or API behavior changes.
- CI behavior remains functionally the same (Dependabot PRs are still auto-approved and auto-merged when checks pass), but uses a different mechanism under the hood.
- Frontend linting behavior may change slightly if `eslint-config-prettier` v10 had different rules or compatibility compared to v9.1.2.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI / Repo maintenance:
  - If the GitHub Script call is misconfigured (e.g., permissions, event context), Dependabot PRs might stop being auto-approved/merged.
- Developer tooling:
  - Developers may see different lint results if they previously had v10 installed locally; version skew between local and lockfile could cause confusion until dependencies are reinstalled.
  - Any config relying on v10-specific behavior could be affected (if such behavior was used).

## 🔎 Suggested Verification (quick checks):
- Open a Dependabot PR (or re-run on an existing one) and confirm:
  - All checks pass.
  - The workflow posts an approval review on the PR.
  - Auto-merge is enabled as expected.
- Run frontend lint locally:
  - `cd frontend && npm install && npm run lint`
  - Confirm no unexpected new errors or warnings compared to prior runs.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add a brief comment in the workflow explaining why `actions/github-script` is preferred over the previous approval action (missing repo / reliability).
- Document the intended version range for `eslint-config-prettier` in contributor docs to avoid accidental upgrades back to incompatible versions.