### PR TITLE
Replaced the Dependabot auto-approval action with a GitHub API call t…

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -66,10 +66,17 @@ jobs:
 
       - name: Auto-approve Dependabot PR
         if: steps.checks.outputs.all_passed == 'true'
-        uses: peter-evans/approve-pull-request@v4
+        uses: actions/github-script@v7
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number,
+              event: 'APPROVE',
+            });
 
       - name: Enable auto-merge
         if: steps.checks.outputs.all_passed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Updated Dependabot config to run daily updates for npm, GitHub Actions, and Docker.
 - Renamed GitHub Actions workflow files to use plural names (`lints.yaml`, `pr_summaries.yaml`).
+- Replaced the Dependabot auto-approval action with a GitHub API call to avoid the missing action repo.
 
 ## 2026-01-18
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Swapped the Dependabot auto-approval GitHub Action for a direct GitHub API call via `actions/github-script`, avoiding reliance on an external action repository that may be missing or unavailable.
- Aligned the frontend dependency on `@emotion/styled` back to `11.14.0` (from `11.14.1`), likely to restore compatibility or avoid issues introduced in the newer patch.
- Documented these changes in the changelog for traceability.

## 📂 Scope (what areas are affected):
- CI / GitHub Actions:
  - `.github/workflows/dependabot_auto_merge.yml` (Dependabot auto-merge pipeline).
- Frontend build & dependencies:
  - `frontend/package.json`
  - `frontend/package-lock.json`
- Project documentation:
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct end-user or API behavior changes.
- CI behavior:
  - Dependabot PRs are still auto-approved and auto-merged when checks pass, but now via the GitHub REST API instead of a third-party action.
- Frontend:
  - Uses `@emotion/styled@11.14.0`; any behavior differences are limited to that library’s patch-level change (likely minimal, but could affect styling edge cases).

## ⚠️ Risk & Impact (what could break / who is affected):
- CI / Automation:
  - If the GitHub Script step is misconfigured (e.g., context assumptions), Dependabot PRs might stop auto-approving/merging, slowing dependency updates.
- Frontend:
  - Reverting `@emotion/styled` could reintroduce any bugs fixed in `11.14.1`, or fix regressions that `11.14.1` caused. Styling or theming behavior at the component level is the most likely impact area.

## 🔎 Suggested Verification (quick checks):
- CI:
  - Open a test Dependabot PR and confirm:
    - All checks run and pass.
    - The workflow posts an approval review on the PR.
    - Auto-merge is enabled and the PR merges without manual intervention.
- Frontend:
  - Run `npm install` in `frontend` and ensure there are no peer-dependency or lockfile warnings.
  - Start the dev server and spot-check a few pages/components that rely heavily on Emotion/MUI styling (layouts, theming, responsive styles) for visual regressions.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add a small CI test or logging step to clearly indicate when Dependabot auto-approval succeeds or fails (for easier debugging).
- Document in contributor docs how Dependabot auto-merge works now (via GitHub Script) and how to adjust it if needed.
- Evaluate whether `@emotion/styled@11.14.1` (or newer) can be safely adopted later, possibly with a targeted visual regression check.