### PR TITLE
Add comprehensive frontend tests for routing, UI, lists and API client

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+const mockSnackbar = jest.fn();
+const mockAuthenticatedRoute = jest.fn(({ children }) => <div>{children}</div>);
+
+jest.mock('./components/MySnackbar', () => (props) => {
+  mockSnackbar(props);
+  return <div data-testid="snackbar" />;
+});
+
+jest.mock('./components/AuthenticatedRoute', () => (props) => mockAuthenticatedRoute(props));
+
+jest.mock('./pages/authentication/Login', () => () => <div>Login Page</div>);
+jest.mock('./pages/authentication/Register', () => () => <div>Register Page</div>);
+jest.mock('./pages/notes/Workspaces', () => () => <div>Workspaces Page</div>);
+jest.mock('./pages/notes/TodoLists', () => () => <div>TodoLists Page</div>);
+jest.mock('./pages/notes/Notes', () => () => <div>Notes Page</div>);
+jest.mock('./components/MyAppBar', () => () => <div>AppBar</div>);
+jest.mock('./components/MyDrawer', () => () => <div>Drawer</div>);
+
+beforeEach(() => {
+  sessionStorage.clear();
+  mockAuthenticatedRoute.mockClear();
+  mockSnackbar.mockClear();
+});
+
+describe('App', () => {
+  test('when navigating to /login, it renders the login route', () => {
+    window.history.pushState({}, '', '/login');
+
+    render(<App />);
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  test('when navigating to /register, it renders the register route', () => {
+    window.history.pushState({}, '', '/register');
+
+    render(<App />);
+
+    expect(screen.getByText('Register Page')).toBeInTheDocument();
+  });
+
+  test('when navigating to /, it wraps protected routes with AuthenticatedRoute', () => {
+    window.history.pushState({}, '', '/');
+
+    render(<App />);
+
+    expect(mockAuthenticatedRoute).toHaveBeenCalled();
+  });
+
+  test('when rendered, it wires the snackbar with defaults', () => {
+    window.history.pushState({}, '', '/login');
+
+    render(<App />);
+
+    expect(mockSnackbar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        open: false,
+        severity: '',
+        message: '',
+      }),
+    );
+  });
+});

--- a/frontend/src/components/AuthenticatedRoute.test.js
+++ b/frontend/src/components/AuthenticatedRoute.test.js
@@ -1,0 +1,51 @@
+import { renderWithProviders } from '../test-utils';
+import { Route, Routes } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import AuthenticatedRoute from './AuthenticatedRoute';
+
+describe('AuthenticatedRoute', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test('when no token exists, it redirects to /login', () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/login" element={<div>Login Screen</div>} />
+        <Route
+          path="/"
+          element={
+            <AuthenticatedRoute>
+              <div>Protected</div>
+            </AuthenticatedRoute>
+          }
+        />
+      </Routes>,
+      { routeEntries: ['/'] },
+    );
+
+    expect(screen.getByText('Login Screen')).toBeInTheDocument();
+    expect(screen.queryByText('Protected')).not.toBeInTheDocument();
+  });
+
+  test('when token exists, it renders children', () => {
+    sessionStorage.setItem('accessToken', 'token');
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/login" element={<div>Login Screen</div>} />
+        <Route
+          path="/"
+          element={
+            <AuthenticatedRoute>
+              <div>Protected</div>
+            </AuthenticatedRoute>
+          }
+        />
+      </Routes>,
+      { routeEntries: ['/'] },
+    );
+
+    expect(screen.getByText('Protected')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MyAppBar.test.js
+++ b/frontend/src/components/MyAppBar.test.js
@@ -1,0 +1,63 @@
+import { renderWithProviders } from '../test-utils';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MyAppBar from './MyAppBar';
+import { useNavigate } from 'react-router-dom';
+import { goBackToParent } from '../utils/Navigation';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../utils/Navigation', () => ({
+  ...jest.requireActual('../utils/Navigation'),
+  goBackToParent: jest.fn(),
+}));
+
+describe('MyAppBar', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(mockNavigate);
+  });
+
+  test('when on /login, it does not render', () => {
+    renderWithProviders(<MyAppBar appBarHeader="" setDrawerOpen={jest.fn()} />, {
+      routeEntries: ['/login'],
+    });
+
+    expect(screen.queryByLabelText(/menu/i)).not.toBeInTheDocument();
+  });
+
+  test('when on a todolist route, it shows the back button and calls navigation helper', async () => {
+    renderWithProviders(<MyAppBar appBarHeader="Todo" setDrawerOpen={jest.fn()} />, {
+      routeEntries: ['/workspace/1/todolist/2'],
+    });
+
+    await userEvent.click(screen.getByLabelText('back button'));
+
+    expect(goBackToParent).toHaveBeenCalledWith('/workspace/1/todolist/2', mockNavigate);
+  });
+
+  test('when menu is clicked, it toggles the drawer state', async () => {
+    const setDrawerOpen = jest.fn();
+
+    renderWithProviders(<MyAppBar appBarHeader="Header" setDrawerOpen={setDrawerOpen} />, {
+      routeEntries: ['/'],
+    });
+
+    await userEvent.click(screen.getByLabelText(/menu/i));
+
+    expect(setDrawerOpen).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  test('when rendered, it shows the header text', () => {
+    renderWithProviders(<MyAppBar appBarHeader="My Header" setDrawerOpen={jest.fn()} />, {
+      routeEntries: ['/'],
+    });
+
+    expect(screen.getByText('My Header')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MyDrawer.test.js
+++ b/frontend/src/components/MyDrawer.test.js
@@ -1,0 +1,138 @@
+import { renderWithProviders } from '../test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MyDrawer from './MyDrawer';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  fetchWorkspace,
+  fetchWorkspaces,
+  updateWorkspace,
+} from '../services/BackendClient';
+import { useNavigate } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../services/BackendClient', () => ({
+  createWorkspace: jest.fn(),
+  deleteWorkspace: jest.fn(),
+  fetchWorkspace: jest.fn(),
+  fetchWorkspaces: jest.fn(),
+  updateWorkspace: jest.fn(),
+}));
+
+const renderDrawer = (options = {}) =>
+  renderWithProviders(
+    <MyDrawer
+      open
+      setDrawerOpen={jest.fn()}
+      drawerWorkspacesLabel=""
+      setDrawerWorkspacesLabel={jest.fn()}
+    />,
+    options,
+  );
+
+describe('MyDrawer', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(mockNavigate);
+    sessionStorage.setItem('accessToken', 'token');
+    fetchWorkspace.mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'Workspace A' }),
+    });
+  });
+
+  test('when loading, it shows a loading state in the workspace list', async () => {
+    fetchWorkspaces.mockReturnValue(new Promise(() => {}));
+
+    renderDrawer();
+
+    await userEvent.click(screen.getByText('Workspace'));
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  test('when the workspace list fails, it shows the error message', async () => {
+    fetchWorkspaces.mockResolvedValue({ ok: false, status: 500, json: async () => [] });
+
+    renderDrawer();
+
+    await userEvent.click(screen.getByText('Workspace'));
+
+    expect(await screen.findByText(/error: http 500/i)).toBeInTheDocument();
+  });
+
+  test('when workspaces load, clicking a list item navigates to it', async () => {
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 3, name: 'Alpha' }],
+    });
+
+    renderDrawer();
+
+    await userEvent.click(screen.getByText('Workspace'));
+
+    await userEvent.click(await screen.findByText('Alpha'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/3');
+  });
+
+  test('when adding a workspace, it appends the new workspace', async () => {
+    fetchWorkspaces.mockResolvedValue({ ok: true, json: async () => [] });
+    createWorkspace.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 9, name: 'New Workspace' }),
+    });
+
+    renderDrawer();
+
+    await userEvent.click(screen.getByText('Workspace'));
+    await userEvent.click(await screen.findByText('Add New'));
+
+    const input = screen.getByPlaceholderText('New Workspace Name...');
+    await userEvent.type(input, 'New Workspace{enter}');
+
+    expect(await screen.findByText('New Workspace')).toBeInTheDocument();
+    expect(createWorkspace).toHaveBeenCalled();
+  });
+
+  test('when editing and deleting a workspace, it updates the list', async () => {
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 4, name: 'Old Name' }],
+    });
+    updateWorkspace.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 4, name: 'Updated Name' }),
+    });
+    deleteWorkspace.mockResolvedValue({ ok: true });
+
+    renderDrawer();
+
+    await userEvent.click(screen.getByText('Workspace'));
+
+    const moreButtons = await screen.findAllByTestId('MoreVertIcon');
+    await userEvent.click(moreButtons[0]);
+    await userEvent.click(screen.getByText('Edit'));
+
+    const editInput = screen.getByDisplayValue('Old Name');
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, 'Updated Name{enter}');
+
+    expect(await screen.findByText('Updated Name')).toBeInTheDocument();
+
+    const updatedMenuIcon = screen.getAllByTestId('MoreVertIcon')[0];
+    await userEvent.click(updatedMenuIcon);
+    await userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Updated Name')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/MySnackbar.test.js
+++ b/frontend/src/components/MySnackbar.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MySnackbar from './MySnackbar';
+
+describe('MySnackbar', () => {
+  test('when rendered, it shows the message and severity', () => {
+    render(
+      <MySnackbar open severity="success" message="Saved!" onClose={jest.fn()} />,
+    );
+
+    expect(screen.getByText('Saved!')).toBeInTheDocument();
+  });
+
+  test('when the close button is clicked, it calls onClose', async () => {
+    const onClose = jest.fn();
+
+    render(<MySnackbar open severity="error" message="Oops" onClose={onClose} />);
+
+    await userEvent.click(screen.getByLabelText(/close/i));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/notes/Notes.test.js
+++ b/frontend/src/pages/notes/Notes.test.js
@@ -1,0 +1,155 @@
+import { renderWithProviders } from '../../test-utils';
+import { Route, Routes } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Notes from './Notes';
+import {
+  createNote,
+  deleteNote,
+  fetchNotes,
+  fetchTodoList,
+  updateNote,
+} from '../../services/BackendClient';
+
+jest.mock('../../services/BackendClient', () => ({
+  createNote: jest.fn(),
+  deleteNote: jest.fn(),
+  fetchNotes: jest.fn(),
+  fetchTodoList: jest.fn(),
+  updateNote: jest.fn(),
+}));
+
+describe('Notes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.setItem('accessToken', 'token');
+  });
+
+  test('when notes load, it fetches list and header', async () => {
+    fetchNotes.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 1, note: 'First Note' }],
+    });
+    fetchTodoList.mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'Todo Header' }),
+    });
+    const setAppBarHeader = jest.fn();
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId/todolist/:todoListId"
+          element={<Notes setAppBarHeader={setAppBarHeader} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1/todolist/2'] },
+    );
+
+    expect(await screen.findByText('First Note')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(setAppBarHeader).toHaveBeenCalledWith('Todo Header');
+    });
+  });
+
+  test('when the notes fail to load, it shows the error', async () => {
+    fetchNotes.mockResolvedValue({ ok: false, status: 500, json: async () => [] });
+    fetchTodoList.mockResolvedValue({ ok: true, json: async () => ({ name: 'Todo Header' }) });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId/todolist/:todoListId"
+          element={<Notes setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1/todolist/2'] },
+    );
+
+    expect(await screen.findByText(/error: http 500/i)).toBeInTheDocument();
+  });
+
+  test('when there are no notes, it shows the empty state', async () => {
+    fetchNotes.mockResolvedValue({ ok: true, json: async () => [] });
+    fetchTodoList.mockResolvedValue({ ok: true, json: async () => ({ name: 'Todo Header' }) });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId/todolist/:todoListId"
+          element={<Notes setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1/todolist/2'] },
+    );
+
+    expect(await screen.findByText('No notes found.')).toBeInTheDocument();
+  });
+
+  test('when adding a note, it appends it', async () => {
+    fetchNotes.mockResolvedValue({ ok: true, json: async () => [] });
+    fetchTodoList.mockResolvedValue({ ok: true, json: async () => ({ name: 'Todo Header' }) });
+    createNote.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 3, note: 'New Note' }),
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId/todolist/:todoListId"
+          element={<Notes setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1/todolist/2'] },
+    );
+
+    await userEvent.click(await screen.findByText('Add New'));
+
+    const input = screen.getByPlaceholderText('New Note…');
+    await userEvent.type(input, 'New Note{enter}');
+
+    expect(await screen.findByText('New Note')).toBeInTheDocument();
+  });
+
+  test('when editing and deleting a note, it updates the list', async () => {
+    fetchNotes.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 6, note: 'Old Note' }],
+    });
+    fetchTodoList.mockResolvedValue({ ok: true, json: async () => ({ name: 'Todo Header' }) });
+    updateNote.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 6, note: 'Updated Note' }),
+    });
+    deleteNote.mockResolvedValue({ ok: true });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId/todolist/:todoListId"
+          element={<Notes setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1/todolist/2'] },
+    );
+
+    const menuIcons = await screen.findAllByTestId('MoreVertIcon');
+    await userEvent.click(menuIcons[0]);
+    await userEvent.click(screen.getByText('Edit'));
+
+    const editInput = screen.getByDisplayValue('Old Note');
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, 'Updated Note{enter}');
+
+    expect(await screen.findByText('Updated Note')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByTestId('MoreVertIcon')[0]);
+    await userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Updated Note')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/notes/TodoLists.test.js
+++ b/frontend/src/pages/notes/TodoLists.test.js
@@ -1,0 +1,120 @@
+import { renderWithProviders } from '../../test-utils';
+import { Route, Routes } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TodoLists from './TodoLists';
+import {
+  createTodoList,
+  deleteTodoList,
+  fetchTodoLists,
+  updateTodoList,
+} from '../../services/BackendClient';
+
+jest.mock('../../services/BackendClient', () => ({
+  createTodoList: jest.fn(),
+  deleteTodoList: jest.fn(),
+  fetchTodoLists: jest.fn(),
+  updateTodoList: jest.fn(),
+}));
+
+describe('TodoLists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.setItem('accessToken', 'token');
+  });
+
+  test('when workspaceId is missing, it does not fetch lists', () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/" element={<TodoLists setAppBarHeader={jest.fn()} />} />
+      </Routes>,
+      { routeEntries: ['/'] },
+    );
+
+    expect(fetchTodoLists).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  test('when lists load, it renders them and allows navigation', async () => {
+    fetchTodoLists.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 2, name: 'Daily' }],
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId"
+          element={<TodoLists setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1'] },
+    );
+
+    expect(await screen.findByText('Daily')).toBeInTheDocument();
+  });
+
+  test('when adding a list, it appends it', async () => {
+    fetchTodoLists.mockResolvedValue({ ok: true, json: async () => [] });
+    createTodoList.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 10, name: 'New List' }),
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId"
+          element={<TodoLists setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1'] },
+    );
+
+    await userEvent.click(await screen.findByText('Add New'));
+
+    const input = screen.getByPlaceholderText('New TodoList Name…');
+    await userEvent.type(input, 'New List{enter}');
+
+    expect(await screen.findByText('New List')).toBeInTheDocument();
+  });
+
+  test('when editing and deleting a list, it updates the list', async () => {
+    fetchTodoLists.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 7, name: 'Old List' }],
+    });
+    updateTodoList.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 7, name: 'Updated List' }),
+    });
+    deleteTodoList.mockResolvedValue({ ok: true });
+
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/workspace/:workspaceId"
+          element={<TodoLists setAppBarHeader={jest.fn()} />}
+        />
+      </Routes>,
+      { routeEntries: ['/workspace/1'] },
+    );
+
+    const menuIcons = await screen.findAllByTestId('MoreVertIcon');
+    await userEvent.click(menuIcons[0]);
+    await userEvent.click(screen.getByText('Edit'));
+
+    const editInput = screen.getByDisplayValue('Old List');
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, 'Updated List{enter}');
+
+    expect(await screen.findByText('Updated List')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByTestId('MoreVertIcon')[0]);
+    await userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Updated List')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/notes/Workspaces.test.js
+++ b/frontend/src/pages/notes/Workspaces.test.js
@@ -1,0 +1,118 @@
+import { renderWithProviders } from '../../test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Workspaces from './Workspaces';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  fetchWorkspaces,
+  updateWorkspace,
+} from '../../services/BackendClient';
+import { useNavigate } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../../services/BackendClient', () => ({
+  createWorkspace: jest.fn(),
+  deleteWorkspace: jest.fn(),
+  fetchWorkspaces: jest.fn(),
+  updateWorkspace: jest.fn(),
+}));
+
+describe('Workspaces', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(mockNavigate);
+    sessionStorage.setItem('accessToken', 'token');
+  });
+
+  test('when loading, it shows a loading state', () => {
+    fetchWorkspaces.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  test('when the workspaces fail to load, it shows the error', async () => {
+    fetchWorkspaces.mockResolvedValue({ ok: false, status: 500, json: async () => [] });
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText(/error: http 500/i)).toBeInTheDocument();
+  });
+
+  test('when there are no workspaces, it shows the empty state', async () => {
+    fetchWorkspaces.mockResolvedValue({ ok: true, json: async () => [] });
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText('No to-do lists found.')).toBeInTheDocument();
+  });
+
+  test('when a workspace is clicked, it navigates to the workspace', async () => {
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 8, name: 'Design' }],
+    });
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    await userEvent.click(await screen.findByText('Design'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/8');
+  });
+
+  test('when adding a workspace, it appends the item', async () => {
+    fetchWorkspaces.mockResolvedValue({ ok: true, json: async () => [] });
+    createWorkspace.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 5, name: 'New Space' }),
+    });
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    await userEvent.click(await screen.findByText('Add New'));
+
+    const input = screen.getByPlaceholderText('New Workspace Name…');
+    await userEvent.type(input, 'New Space{enter}');
+
+    expect(await screen.findByText('New Space')).toBeInTheDocument();
+  });
+
+  test('when editing and deleting, it updates the list', async () => {
+    fetchWorkspaces.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 11, name: 'Old Name' }],
+    });
+    updateWorkspace.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 11, name: 'Updated Name' }),
+    });
+    deleteWorkspace.mockResolvedValue({ ok: true });
+
+    renderWithProviders(<Workspaces setAppBarHeader={jest.fn()} />);
+
+    const moreButtons = await screen.findAllByTestId('MoreVertIcon');
+    await userEvent.click(moreButtons[0]);
+    await userEvent.click(screen.getByText('Edit'));
+
+    const editInput = screen.getByDisplayValue('Old Name');
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, 'Updated Name{enter}');
+
+    expect(await screen.findByText('Updated Name')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByTestId('MoreVertIcon')[0]);
+    await userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Updated Name')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/services/BackendClient.test.js
+++ b/frontend/src/services/BackendClient.test.js
@@ -1,0 +1,199 @@
+import {
+  createNote,
+  createTodoList,
+  createWorkspace,
+  deleteNote,
+  deleteTodoList,
+  deleteWorkspace,
+  fetchNotes,
+  fetchTodoList,
+  fetchTodoLists,
+  fetchWorkspace,
+  fetchWorkspaces,
+  login,
+  register,
+  updateNote,
+  updateTodoList,
+  updateWorkspace,
+} from './BackendClient';
+import { apiFetch } from './client';
+
+jest.mock('./client', () => ({
+  apiFetch: jest.fn(),
+}));
+
+describe('BackendClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when logging in with email, it builds the correct request', () => {
+    login({ email: 'test@example.com', password: 'pass' });
+
+    const [, options] = apiFetch.mock.calls[0];
+
+    expect(apiFetch).toHaveBeenCalledWith('/auth/login/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: options.body,
+    });
+    expect(JSON.parse(options.body)).toEqual({ email: 'test@example.com', password: 'pass' });
+  });
+
+  test('when logging in with username, it builds the correct request', () => {
+    login({ username: 'tester', password: 'pass' });
+
+    const [, options] = apiFetch.mock.calls[0];
+
+    expect(apiFetch).toHaveBeenCalledWith('/auth/login/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: options.body,
+    });
+    expect(JSON.parse(options.body)).toEqual({ username: 'tester', password: 'pass' });
+  });
+
+  test('when registering, it trims the username and email', () => {
+    register({ email: ' test@example.com ', username: ' tester ', password: 'pass' });
+
+    const [, options] = apiFetch.mock.calls[0];
+
+    expect(apiFetch).toHaveBeenCalledWith('/auth/register/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: options.body,
+    });
+    expect(JSON.parse(options.body)).toEqual({
+      email: 'test@example.com',
+      username: 'tester',
+      password: 'pass',
+    });
+  });
+
+  test('when fetching a workspace list, it includes the auth header', () => {
+    fetchWorkspaces('token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when creating a workspace, it sends json headers and payload', () => {
+    createWorkspace({ name: 'New' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'New' }),
+    });
+  });
+
+  test('when updating a workspace, it targets the workspace endpoint', () => {
+    updateWorkspace(3, { name: 'Updated' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/3/', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'Updated' }),
+    });
+  });
+
+  test('when deleting a workspace, it uses the delete verb', () => {
+    deleteWorkspace(5, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/5/', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when fetching todo lists, it adds the workspace query', () => {
+    fetchTodoLists(2, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/?workspace=2', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when creating a todo list, it hits the workspace endpoint', () => {
+    createTodoList(2, { name: 'List' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/?workspace=2', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'List' }),
+    });
+  });
+
+  test('when updating a todo list, it hits the todo list endpoint', () => {
+    updateTodoList(4, { name: 'Updated' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/4/', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'Updated' }),
+    });
+  });
+
+  test('when deleting a todo list, it hits the todo list endpoint', () => {
+    deleteTodoList(6, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/6/', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when fetching notes, it uses the todo_list query', () => {
+    fetchNotes(8, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/notes/?todo_list=8', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when creating notes, it uses the notes endpoint', () => {
+    createNote(8, { note: 'Hello' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/notes/?todo_list=8', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ note: 'Hello' }),
+    });
+  });
+
+  test('when updating notes, it uses the note endpoint', () => {
+    updateNote(10, { note: 'Updated' }, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/notes/10/', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ note: 'Updated' }),
+    });
+  });
+
+  test('when deleting notes, it uses the note endpoint', () => {
+    deleteNote(12, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/notes/12/', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when fetching a workspace, it targets the id endpoint', () => {
+    fetchWorkspace(11, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/11/', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  test('when fetching a todo list, it targets the id endpoint', () => {
+    fetchTodoList(22, 'token');
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/22/', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+});

--- a/frontend/src/services/client.test.js
+++ b/frontend/src/services/client.test.js
@@ -1,0 +1,31 @@
+const originalEnv = process.env;
+
+describe('client apiFetch', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('when no base url is provided, it uses the default', async () => {
+    delete process.env.REACT_APP_API_BASE_URL;
+    const { apiFetch } = await import('./client');
+
+    await apiFetch('/api/test');
+
+    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/api/test', {});
+  });
+
+  test('when a base url is provided, it prefixes requests', async () => {
+    process.env.REACT_APP_API_BASE_URL = 'https://example.com';
+    const { apiFetch } = await import('./client');
+
+    await apiFetch('/api/test', { method: 'GET' });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/api/test', { method: 'GET' });
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,1 +1,47 @@
 import '@testing-library/jest-dom';
+
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+const ignoredWarnings = [
+  'React Router Future Flag Warning',
+  'non-boolean attribute `dense`',
+  'inside a test was not wrapped in act(...).',
+  'A component suspended inside an `act` scope',
+];
+
+const shouldIgnore = (...args) => {
+  const [format] = args;
+  if (typeof format === 'string' && format.includes('non-boolean attribute')) {
+    return true;
+  }
+  const text = args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg;
+      if (arg && typeof arg.message === 'string') return arg.message;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(' ');
+  return ignoredWarnings.some((warning) => text.includes(warning));
+};
+
+beforeAll(() => {
+  console.error = (...args) => {
+    if (shouldIgnore(...args)) return;
+    originalConsoleError(...args);
+  };
+
+  console.warn = (...args) => {
+    if (shouldIgnore(...args)) return;
+    originalConsoleWarn(...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+});

--- a/frontend/src/utils/Navigation.test.js
+++ b/frontend/src/utils/Navigation.test.js
@@ -1,0 +1,31 @@
+import { getParentPath, getWorkspaceId, goBackToParent } from './Navigation';
+
+describe('Navigation helpers', () => {
+  test('when a todolist path is provided, getWorkspaceId returns the workspace id', () => {
+    expect(getWorkspaceId('/workspace/7/todolist/2')).toBe('7');
+  });
+
+  test('when a workspace path is provided, getWorkspaceId returns the workspace id', () => {
+    expect(getWorkspaceId('/workspace/9')).toBe('9');
+  });
+
+  test('when an unrelated path is provided, getWorkspaceId returns null', () => {
+    expect(getWorkspaceId('/login')).toBeNull();
+  });
+
+  test('when a todolist path is provided, getParentPath returns the workspace path', () => {
+    expect(getParentPath('/workspace/4/todolist/11')).toBe('/workspace/4');
+  });
+
+  test('when a workspace path is provided, getParentPath returns root', () => {
+    expect(getParentPath('/workspace/4')).toBe('/');
+  });
+
+  test('when goBackToParent is called, it navigates with replace', () => {
+    const navigate = jest.fn();
+
+    goBackToParent('/workspace/4/todolist/11', navigate);
+
+    expect(navigate).toHaveBeenCalledWith('/workspace/4', { replace: true });
+  });
+});


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds a comprehensive Jest + React Testing Library test suite for the frontend, covering routing, navigation helpers, UI shell components, notes/todolists/workspaces flows, and backend client utilities.
- Verifies that API client functions construct correct URLs, headers, and payloads, and that UI components correctly handle loading, empty, success, and error states.
- Introduces test setup logic to filter out noisy, known React/MUI/React Router warnings so test output is cleaner and more focused.

## 📂 Scope (what areas are affected):
- Frontend routing and shell:
  - `App`, `AuthenticatedRoute`, `MyAppBar`, `MyDrawer`, `MySnackbar`
- Notes domain pages:
  - `Workspaces`, `TodoLists`, `Notes`
- Frontend service layer:
  - `BackendClient` (auth, workspaces, todolists, notes)
  - `client.apiFetch` (base URL handling)
- Navigation utilities:
  - `Navigation` helpers (`getWorkspaceId`, `getParentPath`, `goBackToParent`)
- Global test configuration:
  - `setupTests.js` console warning/error filtering

## 🔄 Behavior Changes (user-visible or API-visible):
- No intentional runtime behavior changes; this PR is test- and tooling-focused.
- Indirectly documents and locks in current behaviors such as:
  - Route protection based on `sessionStorage` `accessToken`.
  - Expected URL shapes for workspace/todolist/note navigation.
  - Default API base URL (`http://127.0.0.1:8000`) and optional `REACT_APP_API_BASE_URL` override.
  - Snackbar default props and visibility behavior.

## ⚠️ Risk & Impact (what could break / who is affected):
- Low runtime risk: production code is largely unchanged; main impact is on the test environment.
- The new console filtering in `setupTests.js` could hide warnings that are not yet in the `ignoredWarnings` list if they match the generic patterns; this only affects test diagnostics, not app behavior.
- If the existing components or API endpoints diverge from the assumptions encoded in tests (paths, query params, headers), tests will fail and block CI until updated.

## 🔎 Suggested Verification (quick checks):
- Run `npm test` / `yarn test` for the frontend and confirm:
  - All new tests pass.
  - Output is free from the previously noisy React Router / MUI / `act(...)` warnings, but still shows unexpected errors.
- Manually sanity-check in the browser (optional but useful):
  - Login/logout flow and redirect behavior for protected routes.
  - Workspace → TodoList → Notes navigation, including back button behavior in the app bar.
  - Creating, editing, and deleting workspaces, todolists, and notes still works as expected.
- Confirm that API calls still hit the expected backend URLs in dev tools (network tab), matching what the tests assert.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add tests for additional components/pages not yet covered (e.g., authentication forms, error boundaries, global layout).
- Extend tests to cover negative/error flows for create/update/delete operations (e.g., failed POST/PATCH/DELETE).
- Consider centralizing common test mocks (e.g., `sessionStorage` token setup, `useNavigate` mocks) to reduce duplication.
- Periodically review `ignoredWarnings` to ensure important new warnings are not being inadvertently suppressed.