### PR TITLE
Fix display name lint errors in App.test.js

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -2,22 +2,40 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 
 const mockSnackbar = jest.fn();
-const mockAuthenticatedRoute = jest.fn(({ children }) => <div>{children}</div>);
+const mockAuthenticatedRoute = jest.fn(function MockAuthenticatedRoute({ children }) {
+  return <div>{children}</div>;
+});
 
-jest.mock('./components/MySnackbar', () => (props) => {
+jest.mock('./components/MySnackbar', () => function MockMySnackbar(props) {
   mockSnackbar(props);
   return <div data-testid="snackbar" />;
 });
 
-jest.mock('./components/AuthenticatedRoute', () => (props) => mockAuthenticatedRoute(props));
+jest.mock('./components/AuthenticatedRoute', () => function MockAuthenticatedRouteWrapper(props) {
+  return mockAuthenticatedRoute(props);
+});
 
-jest.mock('./pages/authentication/Login', () => () => <div>Login Page</div>);
-jest.mock('./pages/authentication/Register', () => () => <div>Register Page</div>);
-jest.mock('./pages/notes/Workspaces', () => () => <div>Workspaces Page</div>);
-jest.mock('./pages/notes/TodoLists', () => () => <div>TodoLists Page</div>);
-jest.mock('./pages/notes/Notes', () => () => <div>Notes Page</div>);
-jest.mock('./components/MyAppBar', () => () => <div>AppBar</div>);
-jest.mock('./components/MyDrawer', () => () => <div>Drawer</div>);
+jest.mock('./pages/authentication/Login', () => function MockLogin() {
+  return <div>Login Page</div>;
+});
+jest.mock('./pages/authentication/Register', () => function MockRegister() {
+  return <div>Register Page</div>;
+});
+jest.mock('./pages/notes/Workspaces', () => function MockWorkspaces() {
+  return <div>Workspaces Page</div>;
+});
+jest.mock('./pages/notes/TodoLists', () => function MockTodoLists() {
+  return <div>TodoLists Page</div>;
+});
+jest.mock('./pages/notes/Notes', () => function MockNotes() {
+  return <div>Notes Page</div>;
+});
+jest.mock('./components/MyAppBar', () => function MockMyAppBar() {
+  return <div>AppBar</div>;
+});
+jest.mock('./components/MyDrawer', () => function MockMyDrawer() {
+  return <div>Drawer</div>;
+});
 
 beforeEach(() => {
   sessionStorage.clear();


### PR DESCRIPTION
## 📌 Summary (what & why):
- Refactors React component mocks in `App.test.js` from anonymous arrow functions to named function components.
- Likely addresses React Testing Library / Jest warnings about component display names or React 18+ expectations for mocked components.
- Improves clarity and debuggability of tests by giving each mock a distinct, readable component name.

## 📂 Scope (what areas are affected):
- Frontend test suite:
  - `App.test.js` and its mocked dependencies:
    - `MySnackbar`
    - `AuthenticatedRoute`
    - Auth pages (Login, Register)
    - Notes pages (Workspaces, TodoLists, Notes)
    - Layout components (MyAppBar, MyDrawer)

## 🔄 Behavior Changes (user-visible or API-visible):
- (none)
- All changes are confined to test code; runtime application behavior and APIs are unchanged.

## ⚠️ Risk & Impact (what could break / who is affected):
- Low risk, limited to test execution:
  - If any test logic depended on the previous mock function shapes or names (e.g., introspecting component types), it could behave differently.
  - If the mock implementations were relied on for specific props behavior, any subtle change in how props are passed through could affect tests (though the intent appears to preserve behavior).

## 🔎 Suggested Verification (quick checks):
- Run frontend tests: `npm test` / `yarn test` and confirm:
  - `App.test.js` passes without new warnings or errors.
  - No new React warnings about invalid component types or missing display names in the test output.
- Optionally run the full frontend test suite to ensure no indirect impacts.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Standardize this named-mock pattern across other test files for consistency.
- Add brief comments in `App.test.js` explaining why named mock components are used (e.g., to avoid React/Jest warnings and improve debugging).