### PR TITLE
Added frontend tests for `MyAppBar` (`frontend/src/components/MyApp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Added PR summary concurrency cancellation to stop outdated summaries on new commits.
 - Added a CRA-compatible frontend ESLint configuration file (`frontend/.eslintrc.js`).
 - Added frontend tests for `AuthenticatedRoute` (`frontend/src/components/AuthenticatedRoute.test.js`).
+- Added frontend tests for `MyAppBar` (`frontend/src/components/MyAppBar.test.js`).
 ### Changed
 - Updated Dependabot config to run daily updates for npm, GitHub Actions, and Docker.
 - Renamed GitHub Actions workflow files to use plural names (`lints.yaml`, `pr_summaries.yaml`).

--- a/frontend/src/components/MyAppBar.test.js
+++ b/frontend/src/components/MyAppBar.test.js
@@ -1,0 +1,84 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import MyAppBar from './MyAppBar';
+import { renderWithProviders } from '../test-utils';
+import { goBackToParent } from '../utils/Navigation';
+
+const mockNavigate = jest.fn();
+const mockUseLocation = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockUseLocation(),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../utils/Navigation', () => ({
+  goBackToParent: jest.fn(),
+}));
+
+describe('MyAppBar', () => {
+  const setDrawerOpen = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/' });
+  });
+
+  test('when the route is /login, it renders nothing', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/login' });
+
+    const { container } = renderWithProviders(
+      <MyAppBar appBarHeader="Header" setDrawerOpen={setDrawerOpen} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('when the route is /register, it renders nothing', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/register' });
+
+    const { container } = renderWithProviders(
+      <MyAppBar appBarHeader="Header" setDrawerOpen={setDrawerOpen} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('when the path includes /todolist, it shows the back button', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/workspaces/1/todolist/2' });
+
+    renderWithProviders(<MyAppBar appBarHeader="Workspace" setDrawerOpen={setDrawerOpen} />);
+
+    expect(screen.getByLabelText('back button')).toBeInTheDocument();
+  });
+
+  test('when the path does not include /todolist, it does not show the back button', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/workspaces/1' });
+
+    renderWithProviders(<MyAppBar appBarHeader="Workspace" setDrawerOpen={setDrawerOpen} />);
+
+    expect(screen.queryByLabelText('back button')).not.toBeInTheDocument();
+  });
+
+  test('when the back button is clicked, it calls goBackToParent', async () => {
+    mockUseLocation.mockReturnValue({ pathname: '/workspaces/1/todolist/2' });
+
+    renderWithProviders(<MyAppBar appBarHeader="Workspace" setDrawerOpen={setDrawerOpen} />);
+
+    await userEvent.click(screen.getByLabelText('back button'));
+
+    expect(goBackToParent).toHaveBeenCalledWith('/workspaces/1/todolist/2', mockNavigate);
+  });
+
+  test('when the menu icon is clicked, it toggles setDrawerOpen', async () => {
+    renderWithProviders(<MyAppBar appBarHeader="Workspace" setDrawerOpen={setDrawerOpen} />);
+
+    await userEvent.click(screen.getByLabelText('menu'));
+
+    expect(setDrawerOpen).toHaveBeenCalled();
+    const [updater] = setDrawerOpen.mock.calls[0];
+    expect(typeof updater).toBe('function');
+  });
+});


### PR DESCRIPTION
## 📌 Summary (what & why):
- Added a dedicated test suite for the `MyAppBar` React component.
- Tests codify expected behavior around when the app bar is visible, when the back button appears, and how navigation/drawer toggling works.
- Changelog updated to document the new frontend tests.

## 📂 Scope (what areas are affected):
- Frontend React component: `MyAppBar`.
- Navigation behavior using `react-router-dom` and the `goBackToParent` utility.
- Layout behavior related to the side drawer toggle.
- Project documentation: `CHANGELOG.md`.

## 🔄 Behavior Changes (user-visible or API-visible):
- (none) — behavior is not changed, only covered by tests.

## ⚠️ Risk & Impact (what could break / who is affected):
- Low risk: changes are limited to tests and documentation.
- Test expectations now “lock in” current `MyAppBar` behavior (e.g., hidden on `/login` and `/register`, back button only on `/todolist` paths). Future UI changes will need to update these tests accordingly.

## 🔎 Suggested Verification (quick checks):
- Run frontend test suite and confirm all tests, including `MyAppBar.test.js`, pass.
- Optionally, manually verify in the app:
  - App bar is hidden on `/login` and `/register`.
  - Back button appears on `/workspaces/:id/todolist/:id` routes and navigates up correctly.
  - Menu icon toggles the side drawer as expected.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add tests for additional `MyAppBar` behaviors (e.g., title rendering, responsiveness, auth-related UI if any).
- Consider adding tests around edge-case routes or malformed paths for `goBackToParent`.