### PR TITLE
Continuous Integration now calls the Dependabot auto-merge workflow a…

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -19,3 +19,13 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/tests.yaml
+
+  dependabot-auto-merge:
+    name: Dependabot Auto Merge
+    needs: [lints, tests]
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: ./.github/workflows/dependabot_auto_merge.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,71 +1,28 @@
-name: Auto Merge
+name: Dependabot Auto Merge
 
 on:
-  workflow_run:
-    workflows: ["Continuous Integration"]
-    types: [completed]
+  workflow_call:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
 jobs:
   dependabot-auto-merge:
-    if: github.event.workflow_run.conclusion == 'success'
+    name: Dependabot Auto Merge
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve pull request
-        id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pullRequests = context.payload.workflow_run.pull_requests;
-            if (!pullRequests || pullRequests.length === 0) {
-              core.setFailed('No pull request found for this workflow run.');
-              return;
-            }
-            const pull_number = pullRequests[0].number;
-            const { owner, repo } = context.repo;
-            const pr = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number,
-            });
-            core.setOutput('number', pull_number.toString());
-            core.setOutput('author', pr.data.user.login);
-
-      - name: Build Dependabot event payload
-        id: event
-        if: steps.pr.outputs.author == 'dependabot[bot]'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const pull_number = Number('${{ steps.pr.outputs.number }}');
-            const { owner, repo } = context.repo;
-            const pr = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number,
-            });
-            const eventPath = path.join(process.env.RUNNER_TEMP, 'dependabot-event.json');
-            fs.writeFileSync(eventPath, JSON.stringify({ pull_request: pr.data }));
-            core.setOutput('path', eventPath);
-
       - name: Fetch Dependabot metadata
         id: metadata
-        if: steps.pr.outputs.author == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@v2
-        env:
-          GITHUB_EVENT_PATH: ${{ steps.event.outputs.path }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summarize major update with ChatGPT
         id: major_summary
-        if: steps.pr.outputs.author == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}
@@ -75,17 +32,12 @@ jobs:
           ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           SCOPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "summary=Missing OPENAI_API_KEY secret." >> "$GITHUB_OUTPUT"
+          if [ -z "$OPENAI_API_KEY" ] || [ -z "$OPENAI_PROJECT_ID" ]; then
+            echo "summary=Missing OpenAI secrets; skipping summary." >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [ -z "$OPENAI_PROJECT_ID" ]; then
-            echo "summary=Missing OPENAI_PROJECT_ID secret." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PROMPT="📦 Dependency Update Summary (Major Version)\n🔖 Package\n\nName: ${PACKAGE_NAME}\n\nFrom → To: ${OLD_VERSION} → ${NEW_VERSION}\n\nEcosystem: ${ECOSYSTEM}\n\nScope: ${SCOPE}\n\n🧠 What Changed (High-Level)\n\nBrief summary of what the new major version introduces\n\nFocus on breaking changes, removed APIs, or behavior shifts\n\nNo marketing fluff\n\n💥 Breaking Changes\n\nList explicit breaking changes\n\nCall out:\n\nRemoved functions / props\n\nRenamed configs\n\nChanged defaults\n\nRequired code changes\n\nIf none are documented, say “No documented breaking changes”\n\n🔄 Required Code or Config Changes\n\nYes / No\n\nIf yes:\n\nWhat files are likely affected\n\nExample changes (if obvious)\n\nIf unknown:\n\nState uncertainty clearly\n\n⚠️ Risk & Impact Assessment\n\nRisk Level: Low | Medium | High\n\nWhy:\n\nRuntime risk?\n\nBuild/test risk?\n\nBehavioral/UI risk?\n\nAreas Most Affected:\n\ne.g. auth, routing, state, styling, API calls\n\n🧪 Test Coverage Confidence\n\nDo existing tests meaningfully cover impacted areas?\n\nAny missing test coverage that increases risk?\n\n📚 Migration & Docs\n\nMigration guide available? Yes / No\n\nLink referenced in changelog? Yes / No\n\nEstimated migration effort:\n\nMinutes | <1 hour | Several hours | Multi-day\n\n✅ Recommendation\n\nChoose one:\n\n✅ Safe to merge after tests\n\n🕒 Merge later (low urgency)\n\n🛑 Do not merge without manual changes\n\n🔍 Needs investigation before decision\n\nOne-sentence justification.\n\n📝 Action Items (If Any)\n\n Update config files\n\n Refactor affected code paths\n\n Add / update tests\n\n Re-run specific checks\n\n🔚 TL;DR\n\nOne sentence:\n\n“This is a high/medium/low-risk major update that does / does not require code changes before merging.”"
+          PROMPT="Dependency Update Summary (Major)\n\nPackage: ${PACKAGE_NAME}\nFrom: ${OLD_VERSION}\nTo: ${NEW_VERSION}\nEcosystem: ${ECOSYSTEM}\nScope: ${SCOPE}\n\nProvide:\n- High-level changes (focus on breaking changes)\n- Required code/config changes (Yes/No + details)\n- Risk level (Low/Medium/High) with rationale\n- Test coverage confidence\n- Migration guide availability\n- Recommendation (merge later / do not merge / needs investigation)\n- TL;DR"
           jq -n \
             --arg prompt "$PROMPT" \
             '
@@ -105,9 +57,6 @@ jobs:
             -H "OpenAI-Project: $OPENAI_PROJECT_ID" \
             --data @body.json)
 
-          echo "Raw response:"
-          echo "$RESPONSE"
-
           SUMMARY=$(echo "$RESPONSE" | jq -r '
             if .choices and .choices[0].message and .choices[0].message.content then
               .choices[0].message.content
@@ -118,9 +67,6 @@ jobs:
             end
           ')
 
-          echo "Summary content:"
-          echo "$SUMMARY"
-
           {
             echo 'summary<<EOF'
             printf '%s\n' "$SUMMARY"
@@ -128,13 +74,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post major update summary to PR
-        if: steps.pr.outputs.author == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUMMARY_BODY: ${{ steps.major_summary.outputs.summary }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER="${{ steps.pr.outputs.number }}"
-
           if [ -z "$SUMMARY_BODY" ]; then
             echo "No summary to post."
             exit 0
@@ -149,12 +94,12 @@ jobs:
             -d @comment.json
 
       - name: Auto-approve Dependabot PR
-        if: steps.pr.outputs.author == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        uses: actions/github-script@v7
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
-            const pull_number = Number('${{ steps.pr.outputs.number }}');
+            const pull_number = context.issue.number;
             await github.rest.pulls.createReview({
               owner,
               repo,
@@ -163,12 +108,12 @@ jobs:
             });
 
       - name: Enable auto-merge
-        if: steps.pr.outputs.author == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        uses: actions/github-script@v7
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
-            const pull_number = Number('${{ steps.pr.outputs.number }}');
+            const pull_number = context.issue.number;
             const query = `
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-01-21
+### Added
+- Added a reusable Dependabot auto-merge workflow (`.github/workflows/dependabot_auto_merge.yml`).
+### Changed
+- Continuous Integration now calls the Dependabot auto-merge workflow after lints/tests for Dependabot PRs.
+
 ## 2026-01-19
 ### Added
 - Added a GitHub Actions workflow to run frontend and backend tests (`tests.yaml`).


### PR DESCRIPTION
## 📌 Summary (what & why):
- Introduces a reusable GitHub Actions workflow dedicated to handling Dependabot PRs (auto-approval, auto-merge, and major-update summaries).
- Integrates this Dependabot workflow into the main Continuous Integration pipeline so it only runs after lints and tests succeed.
- Simplifies and hardens the Dependabot logic by relying directly on the PR context instead of workflow_run indirection, and by making the OpenAI-based summary step safely no-op when secrets are missing.
- Updates the changelog to document the new CI behavior.

## 📂 Scope (what areas are affected):
- GitHub Actions CI configuration:
  - `.github/workflows/continuous_integration.yaml`
  - `.github/workflows/dependabot_auto_merge.yml`
- Project documentation:
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- For Dependabot PRs:
  - After lints and tests pass, the new workflow can automatically:
    - Post a ChatGPT-generated summary comment for major version bumps (when OpenAI secrets are configured).
    - Auto-approve and enable auto-merge for patch/minor updates.
- No changes to application runtime behavior, APIs, or UI; impact is limited to repository automation.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI / automation risk:
  - Misconfiguration could cause Dependabot PRs not to auto-approve/auto-merge as expected.
  - Overly permissive behavior is limited by the explicit check that the PR author is `dependabot[bot]`.
- OpenAI integration:
  - If OpenAI secrets are misconfigured or absent, major-update summaries will simply be skipped (no failure), but maintainers may lose that extra context.
- Affects:
  - Maintainers and reviewers relying on automated dependency update handling.
  - No direct impact on end users of the application.

## 🔎 Suggested Verification (quick checks):
- Open a test Dependabot PR (patch or minor):
  - Confirm CI runs lints/tests, then the Dependabot auto-merge job.
  - Verify the PR gets an approval review and auto-merge is enabled.
- Open a test Dependabot PR with a major version bump:
  - Confirm the workflow runs and, if OpenAI secrets are present, a summary comment is posted.
  - Confirm that missing OpenAI secrets do not fail the workflow but log the “skipping summary” message.
- Ensure non-Dependabot PRs:
  - Do not trigger the Dependabot auto-merge job.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add documentation in CONTRIBUTING or a short CI/automation section explaining how Dependabot PRs are handled and how to configure OpenAI secrets.
- Consider guardrails (labels, protected branches, or environment-specific rules) if some dependencies should never be auto-merged.
- Add monitoring/alerts (e.g., via GitHub Action summary or Slack) for failed Dependabot auto-merge runs to catch configuration drift early.