### PR TITLE
Continuous Integration now passes OpenAI secrets to the Dependabot au…

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -29,3 +29,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -2,6 +2,11 @@ name: Dependabot Auto Merge
 
 on:
   workflow_call:
+    secrets:
+      OPENAI_API_KEY:
+        required: false
+      OPENAI_PROJECT_ID:
+        required: false
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Added a reusable Dependabot auto-merge workflow (`.github/workflows/dependabot_auto_merge.yml`).
 ### Changed
 - Continuous Integration now calls the Dependabot auto-merge workflow after lints/tests for Dependabot PRs.
+- Continuous Integration now passes OpenAI secrets to the Dependabot auto-merge workflow.
 
 ## 2026-01-19
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Wires OpenAI-related secrets (`OPENAI_API_KEY`, `OPENAI_PROJECT_ID`) into the CI workflow so they are available to the reusable Dependabot auto-merge workflow.
- Updates the changelog to document that CI now passes these OpenAI secrets along when invoking the Dependabot auto-merge workflow.

## 📂 Scope (what areas are affected):
- GitHub Actions workflows:
  - Main continuous integration workflow
  - Reusable Dependabot auto-merge workflow
- Project documentation:
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct user-facing or API behavior changes.
- CI/automation behavior changes:
  - Dependabot auto-merge workflow can now optionally access OpenAI credentials when invoked from CI.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI maintainers / repo admins:
  - Misconfigured or missing OpenAI secrets could cause steps that rely on them (now or in future) to fail.
- Security considerations:
  - Broader propagation of OpenAI secrets into workflows increases the importance of guarding against logging or echoing these values.

## 🔎 Suggested Verification (quick checks):
- Trigger CI on a Dependabot PR and confirm:
  - The Dependabot auto-merge workflow runs successfully.
  - Any steps that expect `OPENAI_API_KEY` / `OPENAI_PROJECT_ID` see them as set (e.g., via a safe presence check, not printing values).
- Confirm that non-Dependabot PRs still run CI without regression.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Document in contributor/maintainer docs which workflows use OpenAI secrets and why.
- Add safeguards or conventions to ensure secrets are never logged (e.g., reusable action patterns, linting for `echo` of secret env vars).