### PR TITLE
Dependabot auto-merge now waits for a clean mergeable state before en…

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -20,6 +20,27 @@ jobs:
     name: Tests
     uses: ./.github/workflows/tests.yaml
 
+  dependabot-test-failure-comment:
+    name: Dependabot Test Failure Comment
+    needs: [tests]
+    if: always() && github.event.pull_request.user.login == 'dependabot[bot]' && needs.tests.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment for Codex review
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.issue.number;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body: '@codex review',
+            });
+
   dependabot-auto-merge:
     name: Dependabot Auto Merge
     needs: [lints, tests]

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -119,20 +119,26 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.issue.number;
-            const query = `
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    id
-                  }
-                }
+            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            let pr;
+            for (let attempt = 1; attempt <= 6; attempt += 1) {
+              const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+              pr = data;
+              core.info(`mergeable_state=${pr.mergeable_state} mergeable=${pr.mergeable}`);
+              if (pr.mergeable_state === 'clean' && pr.mergeable !== false) {
+                break;
               }
-            `;
-            const data = await github.graphql(query, {
-              owner,
-              repo,
-              number: pull_number,
-            });
+              if (attempt < 6) {
+                await wait(10000);
+              }
+            }
+
+            if (!pr || pr.mergeable_state !== 'clean' || pr.mergeable === false) {
+              core.warning('PR is not in a mergeable state yet; skipping auto-merge enablement.');
+              return;
+            }
+
             const mutation = `
               mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
                 enablePullRequestAutoMerge(input: {
@@ -149,6 +155,6 @@ jobs:
               }
             `;
             await github.graphql(mutation, {
-              pullRequestId: data.repository.pullRequest.id,
+              pullRequestId: pr.node_id,
               mergeMethod: "MERGE",
             });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project are documented in this file.
 ## 2026-01-21
 ### Added
 - Added a reusable Dependabot auto-merge workflow (`.github/workflows/dependabot_auto_merge.yml`).
+- Added a Dependabot test-failure comment that posts `@codex review`.
 ### Changed
 - Continuous Integration now calls the Dependabot auto-merge workflow after lints/tests for Dependabot PRs.
 - Continuous Integration now passes OpenAI secrets to the Dependabot auto-merge workflow.
+- Dependabot auto-merge now waits for a clean mergeable state before enabling auto-merge.
 
 ## 2026-01-19
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds an automated comment on failing Dependabot PR tests to request a `@codex review`, ensuring bot PRs get human attention when CI breaks.
- Improves the Dependabot auto-merge workflow to wait for GitHub to report a clean, mergeable state before enabling auto-merge, reducing merge race conditions.
- Updates the changelog to document these CI/automation enhancements.

## 📂 Scope (what areas are affected):
- GitHub Actions CI workflow (`continuous_integration.yaml`).
- Reusable Dependabot auto-merge workflow (`dependabot_auto_merge.yml`).
- Project documentation / release notes (`CHANGELOG.md`).

## 🔄 Behavior Changes (user-visible or API-visible):
- For Dependabot PRs:
  - If tests fail, the CI workflow will automatically post a comment `@codex review` on the PR.
  - Auto-merge will only be enabled after the PR is confirmed to be in a clean, mergeable state (with retries), instead of immediately.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI / GitHub Actions:
  - Misconfigured conditions or permissions could prevent the comment from being posted or auto-merge from being enabled.
  - The new mergeability polling logic might skip enabling auto-merge if GitHub never reports a clean state (e.g., unusual PR states), leaving some Dependabot PRs un-auto-merged.
- Maintainers / reviewers:
  - Increased notification volume from `@codex review` comments on failing Dependabot PRs.

## 🔎 Suggested Verification (quick checks):
- Open a test Dependabot PR and:
  - Force tests to fail and confirm a single `@codex review` comment appears on the PR.
  - With passing lints/tests, confirm that auto-merge is enabled only after GitHub reports the PR as mergeable (check Actions logs for `mergeable_state` output).
- Confirm the workflow still behaves normally (no comments, no auto-merge) for non-Dependabot PRs.
- Verify the workflow has `issues: write` permission and can successfully create comments.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add rate-limiting or idempotency checks to avoid duplicate `@codex review` comments on repeated CI runs.
- Expose mergeability wait parameters (attempt count, delay) as reusable workflow inputs for easier tuning.
- Document the Dependabot CI/auto-merge behavior in contributor docs so maintainers know what to expect.