### PR TITLE
Dependabot auto-merge now merges directly when PRs are already clean

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -134,8 +134,28 @@ jobs:
               }
             }
 
-            if (!pr || pr.mergeable_state !== 'clean' || pr.mergeable === false) {
-              core.warning('PR is not in a mergeable state yet; skipping auto-merge enablement.');
+            if (!pr || pr.mergeable === false) {
+              core.warning('PR is not mergeable; skipping auto-merge handling.');
+              return;
+            }
+
+            if (pr.mergeable_state === 'clean') {
+              if (pr.merged) {
+                core.info('PR is already merged; skipping.');
+                return;
+              }
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number,
+                merge_method: 'merge',
+              });
+              core.info('PR merged directly because it is clean.');
+              return;
+            }
+
+            if (pr.mergeable_state === 'unstable') {
+              core.warning('PR is in unstable state; skipping auto-merge enablement.');
               return;
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Continuous Integration now calls the Dependabot auto-merge workflow after lints/tests for Dependabot PRs.
 - Continuous Integration now passes OpenAI secrets to the Dependabot auto-merge workflow.
 - Dependabot auto-merge now waits for a clean mergeable state before enabling auto-merge.
+- Dependabot auto-merge now merges directly when PRs are already clean.
 
 ## 2026-01-19
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the Dependabot auto-merge workflow logic so that:
  - If a Dependabot PR is already in a clean, mergeable state, the workflow merges it directly instead of just enabling auto-merge.
  - Non-mergeable or already-merged PRs are detected early and skipped safely.
- Updates the changelog to document this refined Dependabot auto-merge behavior.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow for Dependabot auto-merge
- Project changelog documentation

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs that are already clean and mergeable will now be merged immediately by the workflow, without waiting on GitHub’s auto-merge mechanism.
- Dependabot PRs in an “unstable” state are explicitly skipped for auto-merge handling.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI / repo automation maintainers:
  - Increased automation: clean Dependabot PRs may merge faster, which could surface issues sooner if tests or protections are misconfigured.
- If branch protection rules or required checks are not correctly enforced by GitHub, this more eager merging could allow problematic dependency updates through.

## 🔎 Suggested Verification (quick checks):
- Create or simulate a Dependabot PR that:
  - Is clean and mergeable: confirm the workflow merges it directly.
  - Is marked non-mergeable: confirm the workflow logs a warning and does not attempt to merge.
  - Is in an “unstable” mergeable_state: confirm it is skipped with the appropriate warning.
- Confirm branch protection and required status checks still prevent merges when they should.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add tests or a dry-run mode for the workflow logic (e.g., via a reusable workflow or mock PRs) to validate behavior across different mergeable states.
- Enhance logging/metrics (e.g., via workflow summary) to track how many Dependabot PRs are merged directly vs. skipped.