### PR TITLE
Dependabot auto-merge now merges directly when PRs are already clean

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -134,8 +134,28 @@ jobs:
               }
             }
 
-            if (!pr || pr.mergeable_state !== 'clean' || pr.mergeable === false) {
-              core.warning('PR is not in a mergeable state yet; skipping auto-merge enablement.');
+            if (!pr || pr.mergeable === false) {
+              core.warning('PR is not mergeable; skipping auto-merge handling.');
+              return;
+            }
+
+            if (pr.mergeable_state === 'clean') {
+              if (pr.merged) {
+                core.info('PR is already merged; skipping.');
+                return;
+              }
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number,
+                merge_method: 'merge',
+              });
+              core.info('PR merged directly because it is clean.');
+              return;
+            }
+
+            if (pr.mergeable_state === 'unstable') {
+              core.warning('PR is in unstable state; skipping auto-merge enablement.');
               return;
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Continuous Integration now calls the Dependabot auto-merge workflow after lints/tests for Dependabot PRs.
 - Continuous Integration now passes OpenAI secrets to the Dependabot auto-merge workflow.
 - Dependabot auto-merge now waits for a clean mergeable state before enabling auto-merge.
+- Dependabot auto-merge now merges directly when PRs are already clean.
 
 ## 2026-01-19
 ### Added


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the Dependabot auto-merge workflow so that when a Dependabot PR is already in a clean, mergeable state, the workflow merges it immediately instead of just enabling auto-merge.
- Clarifies handling of non-mergeable and unstable PR states to avoid unnecessary auto-merge configuration attempts.
- Documents this behavior change in the changelog.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow for Dependabot PR auto-merge.
- Project documentation (CHANGELOG).

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs that are:
  - Mergeable and in a `clean` state: will now be merged directly by the workflow (using the standard `merge` method), without waiting for GitHub’s auto-merge.
  - Explicitly non-mergeable: will be skipped with a warning and no further auto-merge handling.
  - In an `unstable` state: will be skipped for auto-merge enablement, with a clearer warning message.
- Already-merged PRs are detected and skipped gracefully.

## ⚠️ Risk & Impact (what could break / who is affected):
- CI behavior for Dependabot PRs changes slightly: some PRs may merge sooner than before (as soon as they are clean), which could surprise maintainers expecting only auto-merge enablement.
- If the `merge` method is not the desired strategy (e.g., project prefers squash or rebase), this could conflict with repository conventions.
- Any misinterpretation of GitHub’s `mergeable_state` could cause PRs to be merged earlier or later than intended.

## 🔎 Suggested Verification (quick checks):
- Open a test Dependabot PR that passes all checks and is in a `clean` state; confirm the workflow merges it directly and logs the expected messages.
- Open a Dependabot PR that is not mergeable (e.g., with conflicts); confirm the workflow logs the “not mergeable” warning and does nothing further.
- Simulate or identify a PR in an `unstable` state (e.g., checks still running) and ensure the workflow skips auto-merge enablement with the new warning.
- Confirm that already-merged Dependabot PRs do not trigger additional merge attempts.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Make the merge method (`merge` vs `squash` vs `rebase`) configurable via workflow inputs or repository settings.
- Add more granular logging or metrics (e.g., how many PRs were merged directly vs skipped) for observability.
- Extend tests or dry-run checks for the workflow logic to cover all `mergeable_state` variants.