### PR TITLE
auto_merge pls

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -235,8 +235,7 @@ jobs:
             }
 
             if (pr.mergeable_state === 'unstable') {
-              core.warning('PR checks are failing; skipping.');
-              return;
+              core.warning('PR checks are failing; attempting to enable auto-merge anyway.');
             }
 
             if (pr.auto_merge) {


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the Dependabot auto-merge workflow so that it no longer bails out when a PR is in an `unstable` mergeable state (typically when checks are failing or still in flux).
- The workflow will now attempt to enable GitHub’s auto-merge even when checks are failing, relying on GitHub’s own protections and status checks to ultimately allow or block the merge.
- Intent: make Dependabot updates more “hands-off” by letting auto-merge be configured earlier, instead of requiring all checks to be green at the moment the workflow runs.

## 📂 Scope (what areas are affected):
- GitHub Actions CI:
  - `.github/workflows/dependabot_auto_merge.yml` (Dependabot auto-merge logic)

## 🔄 Behavior Changes (user-visible or API-visible):
- For Dependabot PRs in `unstable` state:
  - Previously: the workflow logged a warning and stopped, not enabling auto-merge.
  - Now: the workflow logs a warning but still proceeds to attempt enabling auto-merge.
- No direct change to the application runtime behavior (backend/frontend); this is CI/automation behavior only.

## ⚠️ Risk & Impact (what could break / who is affected):
- If branch protection / required checks are misconfigured, there is a theoretical risk that auto-merge could be enabled on PRs that shouldn’t merge, though GitHub’s required checks should still prevent unsafe merges.
- Developers may see more Dependabot PRs with auto-merge enabled even while checks are red or pending, which could be confusing if they expect auto-merge to appear only after green checks.
- Any issues would primarily affect dependency update PRs, not feature branches.

## 🔎 Suggested Verification (quick checks):
- Open a Dependabot PR where checks are failing or still running and confirm:
  - The workflow runs and logs the updated warning message.
  - Auto-merge is successfully enabled (or GitHub clearly blocks it due to required checks), without the workflow exiting early.
- Confirm that protected branches still cannot be merged while required checks are failing, even if auto-merge is enabled.
- Check the PR timeline to ensure no unexpected immediate merges occur when checks are red.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Document in the contributor/dependency management docs how auto-merge behaves with failing or pending checks, so expectations are clear.
- Consider adding explicit assertions or comments in the workflow explaining reliance on GitHub’s branch protection to prevent unsafe merges.
- Optionally add logging/metrics (e.g., via workflow annotations) to track how often auto-merge is attempted on `unstable` PRs and whether merges ultimately succeed or fail.