### PR TITLE
auto merge structure changes

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -44,12 +44,15 @@ jobs:
   dependabot-auto-merge:
     name: Dependabot Auto Merge
     needs: [lints, tests]
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && needs.lints.result == 'success' && needs.tests.result == 'success'
     uses: ./.github/workflows/dependabot_auto_merge.yml
     permissions:
       contents: write
       pull-requests: write
       issues: write
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_author: ${{ github.event.pull_request.user.login }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -2,6 +2,13 @@ name: Dependabot Auto Merge
 
 on:
   workflow_call:
+    inputs:
+      pr_number:
+        required: false
+        type: number
+      pr_author:
+        required: false
+        type: string
     secrets:
       OPENAI_API_KEY:
         required: false
@@ -16,8 +23,10 @@ permissions:
 jobs:
   dependabot-auto-merge:
     name: Dependabot Auto Merge
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || inputs.pr_author == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
@@ -83,7 +92,6 @@ jobs:
         uses: actions/github-script@v8
         env:
           SUMMARY_BODY: ${{ steps.major_summary.outputs.summary }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -146,8 +154,6 @@ jobs:
       - name: Auto-approve Dependabot PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         uses: actions/github-script@v8
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -187,8 +193,6 @@ jobs:
       - name: Enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         uses: actions/github-script@v8
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -201,11 +205,10 @@ jobs:
             }
 
             let pr;
-            const maxAttempts = 4;
+            const maxAttempts = 3;
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
               const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
               pr = data;
-              core.info(`mergeable_state=${pr.mergeable_state} mergeable=${pr.mergeable}`);
               if (pr.mergeable !== null && pr.mergeable_state && pr.mergeable_state !== 'unknown') {
                 break;
               }
@@ -232,10 +235,6 @@ jobs:
             if (pr.mergeable === false || pr.mergeable_state === 'dirty') {
               core.warning('PR has merge conflicts; skipping.');
               return;
-            }
-
-            if (pr.mergeable_state === 'unstable') {
-              core.warning('PR checks are failing; attempting to enable auto-merge anyway.');
             }
 
             if (pr.auto_merge) {


### PR DESCRIPTION
## 📌 Summary (what & why):
- Tightens Dependabot auto-merge so it only runs after lints and tests succeed.
- Makes the reusable `dependabot_auto_merge` workflow more flexible by accepting PR number/author as inputs, allowing it to be called from other workflows.
- Simplifies and slightly hardens the auto-merge logic (fewer attempts, less noisy logging, no special handling for “unstable” mergeable state).

## 📂 Scope (what areas are affected):
- GitHub Actions CI workflow (`continuous_integration.yaml`).
- Reusable Dependabot auto-merge workflow (`dependabot_auto_merge.yml`).

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs will only be auto-merged if:
  - They are created by `dependabot[bot]`, and
  - Both `lints` and `tests` jobs have succeeded.
- The auto-merge workflow can now be invoked with explicit `pr_number` and `pr_author` inputs, instead of relying solely on `github.event.pull_request`.
- The auto-merge script:
  - Tries fewer times (3 instead of 4) to get a stable `mergeable_state`.
  - No longer logs detailed `mergeable_state` info or warns when the state is `unstable`; it simply respects the final state.

## ⚠️ Risk & Impact (what could break / who is affected):
- If `lints` or `tests` are flaky or misconfigured, Dependabot PRs may stop auto-merging even when they are otherwise safe.
- Any external or future workflow that calls `dependabot_auto_merge.yml` must pass `pr_number`/`pr_author` correctly if it doesn’t have a `pull_request` context.
- Slightly fewer attempts to resolve `mergeable_state` could, in rare timing edge cases, cause auto-merge to be skipped if GitHub hasn’t computed mergeability yet.

## 🔎 Suggested Verification (quick checks):
- Open a Dependabot PR that passes both lints and tests:
  - Confirm the `dependabot-auto-merge` job runs and auto-merge is enabled as expected.
- Temporarily force a lint or test failure on a Dependabot PR:
  - Confirm the auto-merge workflow does not run (or does not enable auto-merge).
- Manually trigger or simulate a workflow_call to `dependabot_auto_merge.yml` with explicit `pr_number` and `pr_author`:
  - Confirm it correctly identifies the PR and behaves the same as when triggered directly from a PR.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add a small README or inline docs for `dependabot_auto_merge.yml` explaining required inputs and typical calling patterns.
- Consider adding logging around when auto-merge is skipped due to unresolved `mergeable_state` to aid debugging rare edge cases.