### PR TITLE
auto run consolidataion

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -50,9 +50,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    with:
-      pr_number: ${{ github.event.pull_request.number }}
-      pr_author: ${{ github.event.pull_request.user.login }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -2,13 +2,6 @@ name: Dependabot Auto Merge
 
 on:
   workflow_call:
-    inputs:
-      pr_number:
-        required: false
-        type: number
-      pr_author:
-        required: false
-        type: string
     secrets:
       OPENAI_API_KEY:
         required: false
@@ -23,10 +16,10 @@ permissions:
 jobs:
   dependabot-auto-merge:
     name: Dependabot Auto Merge
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || inputs.pr_author == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
-      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
@@ -35,8 +28,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summarize major update with ChatGPT
-        id: major_summary
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        uses: actions/github-script@v8
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}
@@ -45,71 +38,61 @@ jobs:
           NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
           ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           SCOPE: ${{ steps.metadata.outputs.dependency-type }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ] || [ -z "$OPENAI_PROJECT_ID" ]; then
-            echo "summary=Missing OpenAI secrets; skipping summary." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PROMPT="Dependency Update Summary (Major)\n\nPackage: ${PACKAGE_NAME}\nFrom: ${OLD_VERSION}\nTo: ${NEW_VERSION}\nEcosystem: ${ECOSYSTEM}\nScope: ${SCOPE}\n\nProvide:\n- High-level changes (focus on breaking changes)\n- Required code/config changes (Yes/No + details)\n- Risk level (Low/Medium/High) with rationale\n- Test coverage confidence\n- Migration guide availability\n- Recommendation (merge later / do not merge / needs investigation)\n- TL;DR"
-          jq -n \
-            --arg prompt "$PROMPT" \
-            '
-            {
-              model: "gpt-5.1",
-              temperature: 0.2,
-              messages: [
-                { "role": "system", "content": "You summarize dependency major updates for maintainers." },
-                { "role": "user", "content": $prompt }
-              ]
-            }
-            ' > body.json
-
-          RESPONSE=$(curl -s -X POST "https://api.openai.com/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "OpenAI-Project: $OPENAI_PROJECT_ID" \
-            --data @body.json)
-
-          SUMMARY=$(echo "$RESPONSE" | jq -r '
-            if .choices and .choices[0].message and .choices[0].message.content then
-              .choices[0].message.content
-            elif .error and .error.message then
-              "OpenAI API error: " + .error.message
-            else
-              "OpenAI did not return a summary."
-            end
-          ')
-
-          {
-            echo 'summary<<EOF'
-            printf '%s\n' "$SUMMARY"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Post major update summary to PR
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        uses: actions/github-script@v8
-        env:
-          SUMMARY_BODY: ${{ steps.major_summary.outputs.summary }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const pull_number = Number(process.env.PR_NUMBER);
-            const summaryBody = (process.env.SUMMARY_BODY || '').trim();
+            const {
+              OPENAI_API_KEY,
+              OPENAI_PROJECT_ID,
+              PACKAGE_NAME,
+              OLD_VERSION,
+              NEW_VERSION,
+              ECOSYSTEM,
+              SCOPE,
+            } = process.env;
 
             if (!pull_number) {
               core.warning('PR number is not available; skipping summary comment.');
               return;
             }
 
-            if (!summaryBody) {
-              core.info('No summary to post.');
-              return;
+            let summary = 'Missing OpenAI secrets; skipping summary.';
+            if (OPENAI_API_KEY && OPENAI_PROJECT_ID) {
+              const prompt = `Dependency Update Summary (Major)\n\nPackage: ${PACKAGE_NAME}\nFrom: ${OLD_VERSION}\nTo: ${NEW_VERSION}\nEcosystem: ${ECOSYSTEM}\nScope: ${SCOPE}\n\nProvide:\n- High-level changes (focus on breaking changes)\n- Required code/config changes (Yes/No + details)\n- Risk level (Low/Medium/High) with rationale\n- Test coverage confidence\n- Migration guide availability\n- Recommendation (merge later / do not merge / needs investigation)\n- TL;DR`;
+
+              try {
+                const response = await fetch('https://api.openai.com/v1/chat/completions', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${OPENAI_API_KEY}`,
+                    'OpenAI-Project': OPENAI_PROJECT_ID,
+                  },
+                  body: JSON.stringify({
+                    model: 'gpt-5.1',
+                    temperature: 0.2,
+                    messages: [
+                      { role: 'system', content: 'You summarize dependency major updates for maintainers.' },
+                      { role: 'user', content: prompt },
+                    ],
+                  }),
+                });
+                const data = await response.json();
+                summary = data?.choices?.[0]?.message?.content;
+                if (!summary) {
+                  summary = data?.error?.message
+                    ? `OpenAI API error: ${data.error.message}`
+                    : 'OpenAI did not return a summary.';
+                }
+              } catch (error) {
+                summary = `OpenAI API error: ${error?.message || 'Unknown error'}`;
+              }
             }
 
             const marker = '<!-- dependabot-major-summary -->';
-            const body = `${summaryBody}\n\n${marker}`;
+            const summaryText = summary.trim();
+            const body = `${summaryText}\n\n${marker}`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -128,7 +111,7 @@ jobs:
 
             if (existing) {
               const cleanedExisting = existing.body.replace(marker, '').trim();
-              if (cleanedExisting === summaryBody) {
+              if (cleanedExisting === summaryText) {
                 core.info('Summary comment already up to date; skipping.');
                 return;
               }
@@ -151,16 +134,17 @@ jobs:
             });
             core.info('Summary comment posted.');
 
-      - name: Auto-approve Dependabot PR
+      - name: Approve and enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
             const pull_number = Number(process.env.PR_NUMBER);
+            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
             if (!pull_number) {
-              core.warning('PR number is not available; skipping auto-approve.');
+              core.warning('PR number is not available; skipping.');
               return;
             }
 
@@ -178,30 +162,13 @@ jobs:
                 review.state === 'APPROVED'
             );
 
-            if (alreadyApproved) {
-              core.info('PR already approved by github-actions[bot]; skipping.');
-              return;
-            }
-
-            await github.rest.pulls.createReview({
-              owner,
-              repo,
-              pull_number,
-              event: 'APPROVE',
-            });
-
-      - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const pull_number = Number(process.env.PR_NUMBER);
-            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-            if (!pull_number) {
-              core.warning('PR number is not available; skipping auto-merge.');
-              return;
+            if (!alreadyApproved) {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number,
+                event: 'APPROVE',
+              });
             }
 
             let pr;
@@ -222,13 +189,8 @@ jobs:
               return;
             }
 
-            if (pr.merged) {
-              core.info('PR is already merged; skipping.');
-              return;
-            }
-
-            if (pr.draft) {
-              core.warning('PR is a draft; skipping.');
+            if (pr.merged || pr.draft) {
+              core.info('PR is already merged or a draft; skipping auto-merge.');
               return;
             }
 
@@ -247,21 +209,7 @@ jobs:
               return;
             }
 
-            const mutation = `
-              mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId,
-                  mergeMethod: $mergeMethod
-                }) {
-                  pullRequest {
-                    number
-                    autoMergeRequest {
-                      enabledAt
-                    }
-                  }
-                }
-              }
-            `;
+            const mutation = 'mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) { pullRequest { number } } }';
             try {
               await github.graphql(mutation, {
                 pullRequestId: pr.node_id,


### PR DESCRIPTION
## 📌 Summary (what & why):
- Simplifies how the Dependabot auto-merge workflow is invoked and how it identifies Dependabot PRs.
- Moves the OpenAI major-update summary generation fully into a single `github-script` step instead of a separate shell + curl step.
- Keeps the same behavior for auto-approving and enabling auto-merge on minor/patch updates, but consolidates it into one script and tightens some guard conditions.

## 📂 Scope (what areas are affected):
- GitHub Actions workflows:
  - `.github/workflows/continuous_integration.yaml`
  - `.github/workflows/dependabot_auto_merge.yml`
- Dependabot PR handling (major vs minor/patch updates).
- OpenAI-based summary generation for major dependency updates.

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot auto-merge workflow:
  - Only triggers for actual Dependabot PRs using `github.event.pull_request.user.login == 'dependabot[bot]'` (no longer supports passing a `pr_author` input).
  - PR number is always taken from the GitHub event; no optional `pr_number` input.
- Major updates:
  - The OpenAI summary is now generated and posted in a single `github-script` step using `fetch` instead of a separate shell script with `curl` and `jq`.
  - If OpenAI secrets are missing, the PR comment explicitly states that the summary was skipped due to missing secrets.
  - The workflow still avoids duplicate comments by updating an existing summary comment when content changes.
- Minor/patch updates:
  - Approval and enabling auto-merge are handled in one script step instead of two.
  - If the PR is already merged or is a draft, the script logs and skips auto-merge in a single check.

## ⚠️ Risk & Impact (what could break / who is affected):
- If the `github-script` environment doesn’t support `fetch` as used, major-update summaries might fail to post.
- Any external callers that previously invoked `dependabot_auto_merge.yml` via `workflow_call` with `pr_number`/`pr_author` inputs will no longer work as before (those inputs are removed).
- If OpenAI API behavior or response shape changes, summary extraction (`choices[0].message.content`) could fail, leading to generic error messages in the PR comment.
- Auto-merge behavior for Dependabot PRs relies more strictly on the event context; misconfigured triggers could prevent the workflow from running.

## 🔎 Suggested Verification (quick checks):
- Open a test Dependabot PR with:
  - A major version bump:
    - Confirm the workflow runs.
    - Confirm a single summary comment is posted with the expected structure.
    - Re-run or update the PR to ensure the comment is updated, not duplicated.
  - A minor/patch version bump:
    - Confirm the PR is auto-approved (if not already) and auto-merge is enabled.
- Temporarily remove or mask `OPENAI_API_KEY` / `OPENAI_PROJECT_ID`:
  - Confirm the major-update step posts a “Missing OpenAI secrets; skipping summary.” comment instead of failing the workflow.
- Confirm that no other workflows rely on calling `dependabot_auto_merge.yml` with `inputs.pr_number` or `inputs.pr_author`.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add explicit logging around the OpenAI API call (status code, truncated response) to make debugging easier if summaries fail.
- Consider adding a timeout or retry logic for the OpenAI request to avoid hanging workflows.
- Document in the repo’s CONTRIBUTING/infra docs how Dependabot auto-merge and OpenAI summaries work, including required secrets and limitations.