### PR TITLE
removed approval, just auto merge

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -134,7 +134,7 @@ jobs:
             });
             core.info('Summary comment posted.');
 
-      - name: Approve and enable auto-merge
+      - name: Enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         uses: actions/github-script@v8
         with:
@@ -146,29 +146,6 @@ jobs:
             if (!pull_number) {
               core.warning('PR number is not available; skipping.');
               return;
-            }
-
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner,
-              repo,
-              pull_number,
-              per_page: 100,
-            });
-
-            const alreadyApproved = reviews.some(
-              (review) =>
-                review.user &&
-                review.user.login === 'github-actions[bot]' &&
-                review.state === 'APPROVED'
-            );
-
-            if (!alreadyApproved) {
-              await github.rest.pulls.createReview({
-                owner,
-                repo,
-                pull_number,
-                event: 'APPROVE',
-              });
             }
 
             let pr;


### PR DESCRIPTION
## 📌 Summary (what & why):
- Removes the automatic "approve" step from the Dependabot auto-merge workflow.
- The workflow now only enables auto-merge for eligible Dependabot PRs without adding an approval review from `github-actions[bot]`.
- Likely aligns with updated repository policies or GitHub rules that no longer require (or allow) bot self-approval.

## 📂 Scope (what areas are affected):
- GitHub Actions CI:
  - `.github/workflows/dependabot_auto_merge.yml` (Dependabot auto-merge logic)

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs that qualify (semver patch/minor) will:
  - Still have auto-merge enabled.
  - No longer receive an automated approval review from the GitHub Actions bot.
- Any checks or branch protection rules that relied on that bot approval will no longer see it.

## ⚠️ Risk & Impact (what could break / who is affected):
- If branch protection rules require at least one approval and no human or other bot approval is present, auto-merge may stop working for Dependabot PRs.
- Teams relying on the visual signal of the bot’s approval in the PR timeline will no longer see it.
- If the repository previously depended on this approval to satisfy policy, merges might silently stop until rules are adjusted.

## 🔎 Suggested Verification (quick checks):
- Open a test Dependabot PR with a semver patch or minor update and confirm:
  - The workflow runs successfully.
  - Auto-merge is enabled on the PR.
  - No `github-actions[bot]` approval review is added.
- Confirm branch protection rules:
  - Ensure they don’t require an approval that only this bot used to provide.
- Verify that at least one Dependabot PR fully auto-merges as expected.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Update repository documentation or onboarding notes to clarify how Dependabot PRs are now approved/merged.
- If needed, adjust branch protection rules to:
  - Either not require approvals for Dependabot PRs, or
  - Require human review instead of bot approval.