### PR TITLE
added delay

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -148,6 +148,8 @@ jobs:
               return;
             }
 
+            await wait(10000);
+
             let pr;
             const maxAttempts = 3;
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds a 10-second delay before attempting to auto-merge Dependabot PRs in the GitHub Actions workflow.
- Likely intended to give GitHub time to fully register the PR state (e.g., checks, labels, permissions) before the script starts polling and acting, reducing flaky failures.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow: `.github/workflows/dependabot_auto_merge.yml`
- Only the Dependabot auto-merge automation behavior is touched; no application code (backend/frontend) is affected.

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs will now wait at least ~10 seconds after the workflow step starts before the auto-merge logic begins retrying.
- From a maintainer’s perspective, auto-merges may appear slightly slower, but more stable/less error-prone.

## ⚠️ Risk & Impact (what could break / who is affected):
- Minimal risk: only affects CI automation, not runtime behavior of the app.
- If the delay is insufficient or too long, it could:
  - Still allow occasional race conditions (if GitHub is slower than 10s).
  - Slightly delay merging of Dependabot PRs, which might slow dependency updates in very time-sensitive workflows.

## 🔎 Suggested Verification (quick checks):
- Open a new Dependabot PR and confirm:
  - The auto-merge workflow runs successfully without intermittent “PR not found” or similar race-condition errors.
  - The PR eventually merges as expected once conditions (checks, approvals, labels) are satisfied.
- Review workflow logs to ensure the delay is applied and no new errors appear around the wait period.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Make the wait duration configurable via an environment variable or input for easier tuning.
- Add logging around the wait (e.g., “Waiting 10s before starting auto-merge attempts”) to improve observability.
- If race conditions persist, consider a more robust readiness check instead of (or in addition to) a fixed delay.