### PR TITLE
looping while waiting for stabililty

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -148,18 +148,21 @@ jobs:
               return;
             }
 
-            await wait(10000);
-
             let pr;
-            const maxAttempts = 3;
+            const maxAttempts = 36;
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              if (attempt > 1) {
+                await wait(5000);
+              }
               const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
               pr = data;
-              if (pr.mergeable !== null && pr.mergeable_state && pr.mergeable_state !== 'unknown') {
+              if (
+                pr.mergeable !== null &&
+                pr.mergeable_state &&
+                pr.mergeable_state !== 'unknown' &&
+                pr.mergeable_state !== 'unstable'
+              ) {
                 break;
-              }
-              if (attempt < maxAttempts) {
-                await wait(5000);
               }
             }
 
@@ -183,8 +186,8 @@ jobs:
               return;
             }
 
-            if (pr.mergeable == null || pr.mergeable_state === 'unknown') {
-              core.warning('PR mergeability is still being calculated; skipping for now.');
+            if (pr.mergeable == null || pr.mergeable_state === 'unknown' || pr.mergeable_state === 'unstable') {
+              core.warning('PR is not yet in a stable mergeable state; skipping for now.');
               return;
             }
 


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the Dependabot auto-merge GitHub Action to be more patient and conservative when deciding if a PR is safe to merge.
- Increases the number of attempts and refines the conditions used to determine when GitHub has finished computing a PR’s mergeability.
- Aims to reduce flaky or premature auto-merges when GitHub reports an “unstable” or still-calculating merge state.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow for Dependabot auto-merge behavior.
- No changes to application code (Django backend, React frontend) or Docker setup.

## 🔄 Behavior Changes (user-visible or API-visible):
- Dependabot PRs will:
  - Be polled up to 36 times (with 5-second intervals after the first attempt) while GitHub computes mergeability.
  - Be skipped for auto-merge when the merge state is `unknown` or `unstable`, not just when it’s still `unknown`.
- This may delay or prevent some auto-merges that previously might have gone through while mergeability was still in flux.

## ⚠️ Risk & Impact (what could break / who is affected):
- Auto-merging of Dependabot PRs may become slower or less frequent, especially for PRs that linger in an `unstable` state.
- If GitHub’s mergeability never stabilizes for certain PRs, they will require manual review/merge.
- No direct impact on end users; impact is on maintainers’ workflow and automation reliability.

## 🔎 Suggested Verification (quick checks):
- Open a Dependabot PR and observe the workflow logs:
  - Confirm it retries multiple times (up to 36 attempts) before giving up.
  - Confirm it logs the updated warning message when mergeability is `unknown` or `unstable`.
- Create a test PR where mergeability is temporarily unstable (e.g., changing branch protection or CI status) and ensure the workflow does not auto-merge while in that state.
- Confirm that a clearly mergeable Dependabot PR still auto-merges as expected.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add logging/metrics around how often PRs end up in `unstable` vs `unknown` vs stable states to tune retry counts and delays.
- Document the auto-merge behavior and edge cases in contributor docs so maintainers know why some Dependabot PRs are skipped.
- Consider a maximum wall-clock wait time or backoff strategy instead of a fixed attempt count.