### PR TITLE
merge unstable

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -141,7 +141,6 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pull_number = Number(process.env.PR_NUMBER);
-            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
             if (!pull_number) {
               core.warning('PR number is not available; skipping.');
@@ -149,22 +148,8 @@ jobs:
             }
 
             let pr;
-            const maxAttempts = 36;
-            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-              if (attempt > 1) {
-                await wait(5000);
-              }
-              const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
-              pr = data;
-              if (
-                pr.mergeable !== null &&
-                pr.mergeable_state &&
-                pr.mergeable_state !== 'unknown' &&
-                pr.mergeable_state !== 'unstable'
-              ) {
-                break;
-              }
-            }
+            const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+            pr = data;
 
             if (!pr) {
               core.warning('PR data not available; skipping auto-merge handling.');
@@ -183,6 +168,23 @@ jobs:
 
             if (pr.auto_merge) {
               core.info('Auto-merge is already enabled; skipping.');
+              return;
+            }
+
+            if (pr.mergeable === true && pr.mergeable_state === 'unstable') {
+              core.warning('PR is unstable; attempting immediate merge anyway.');
+              try {
+                await github.rest.pulls.merge({
+                  owner,
+                  repo,
+                  pull_number,
+                  merge_method: 'merge',
+                });
+                core.info('PR merged directly while unstable.');
+              } catch (error) {
+                const message = error?.message || 'Unknown error';
+                core.warning(`Immediate merge failed: ${message}`);
+              }
               return;
             }
 


### PR DESCRIPTION
## 📌 Summary (what & why):
- Simplifies the Dependabot auto-merge workflow’s logic for checking PR mergeability.
- Adds a special case to *attempt* merging PRs that are marked `mergeable === true` but have an `unstable` mergeable state.
- Aims to reduce unnecessary waiting/retries and allow more Dependabot PRs to auto-merge without manual intervention.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow: `.github/workflows/dependabot_auto_merge.yml`
- Only affects automated handling of Dependabot pull requests (no app/runtime code).

## 🔄 Behavior Changes (user-visible or API-visible):
- The workflow now:
  - Fetches PR data once instead of polling repeatedly for a stable mergeable state.
  - If a PR is `mergeable === true` and `mergeable_state === 'unstable'`, it will immediately attempt to merge instead of skipping.
  - If that immediate merge fails, it logs a warning but does not retry within the same run.
- For other cases where mergeability is unknown/unstable, the workflow still skips auto-merge.

## ⚠️ Risk & Impact (what could break / who is affected):
- Slightly higher chance of merge failures for Dependabot PRs due to:
  - No longer waiting for GitHub to fully compute a stable mergeable state.
  - Attempting merges in an `unstable` state may occasionally hit race conditions (e.g., concurrent updates, pending checks).
- Impact is limited to automated Dependabot PRs; human-driven PRs are unaffected.
- Failed merges will surface as workflow warnings rather than silently succeeding.

## 🔎 Suggested Verification (quick checks):
- Open a Dependabot PR and:
  - Ensure the auto-merge workflow runs and logs the PR’s mergeability status.
  - If the PR shows `mergeable === true` but `mergeable_state === 'unstable'` in the logs, confirm the workflow attempts a merge and either:
    - Successfully merges the PR, or
    - Logs a clear warning on failure.
- Confirm that PRs with `mergeable_state === 'unknown'` or `null` are skipped with an appropriate warning message.
- Check that no non-Dependabot PRs are affected by this workflow.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add more granular logging around why GitHub reports `unstable` (e.g., pending checks vs. conflicts) if available.
- Consider a small retry/backoff for failed “unstable but mergeable” merges to handle transient GitHub states.
- Document the intended behavior of auto-merge for maintainers (e.g., in CONTRIBUTING or repo docs) so they understand why some Dependabot PRs may still be skipped.