### PR TITLE
converted to more native functions

### DIFF
--- a/.github/workflows/pr_summary.yaml
+++ b/.github/workflows/pr_summary.yaml
@@ -50,85 +50,95 @@ jobs:
 
       - name: Call OpenAI
         id: openai
+        uses: actions/github-script@v7
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "summary=Missing OPENAI_API_KEY secret." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        with:
+          script: |
+            const fs = require('fs');
 
-          if [ -z "$OPENAI_PROJECT_ID" ]; then
-            echo "summary=Missing OPENAI_PROJECT_ID secret." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            const apiKey = process.env.OPENAI_API_KEY;
+            const projectId = process.env.OPENAI_PROJECT_ID;
 
-          # Keep diff formatting (no flattening)
-          DIFF_CONTENT=$(cat pr.diff)
+            if (!apiKey) {
+              core.setOutput('summary', 'Missing OPENAI_API_KEY secret.');
+              return;
+            }
 
-          # Build prompt
-          PROMPT="You are a PR summarizer for the Notoli project (Backend: Django; Frontend: React + MUI; Docker; GitHub Actions). Produce a high-level, human-readable digest of what changed and why it matters. Focus on intent, scope, behavior changes, and impact. Do NOT do a code review. Do NOT list line-by-line or file-by-file changes. Do NOT restate the diff. Be concise. If the diff is truncated, explicitly note that the summary may be incomplete. Your response MUST use the following exact sections, in order, each containing bullet points (or '(none)' if empty): ## 📌 Summary (what & why): ## 📂 Scope (what areas are affected): ## 🔄 Behavior Changes (user-visible or API-visible): ## ⚠️ Risk & Impact (what could break / who is affected): ## 🔎 Suggested Verification (quick checks): ## ➕ Follow-ups (nice-to-do, not required for merge): Here is the diff: ${DIFF_CONTENT}"
+            if (!projectId) {
+              core.setOutput('summary', 'Missing OPENAI_PROJECT_ID secret.');
+              return;
+            }
 
-          # Build JSON safely
-          jq -n \
-            --arg prompt "$PROMPT" \
-            '
-            {
+            const diffContent = fs.readFileSync('pr.diff', 'utf8');
+            const prompt = [
+              "You are a PR summarizer for the Notoli project (Backend: Django; Frontend: React + MUI; Docker; GitHub Actions).",
+              "Produce a high-level, human-readable digest of what changed and why it matters.",
+              "Focus on intent, scope, behavior changes, and impact.",
+              "Do NOT do a code review.",
+              "Do NOT list line-by-line or file-by-file changes.",
+              "Do NOT restate the diff.",
+              "Be concise.",
+              "If the diff is truncated, explicitly note that the summary may be incomplete.",
+              "Your response MUST use the following exact sections, in order, each containing bullet points (or '(none)' if empty):",
+              "## Summary (what & why):",
+              "## Scope (what areas are affected):",
+              "## Behavior Changes (user-visible or API-visible):",
+              "## Risk & Impact (what could break / who is affected):",
+              "## Suggested Verification (quick checks):",
+              "## Follow-ups (nice-to-do, not required for merge):",
+              "Here is the diff:",
+              diffContent
+            ].join(' ');
+
+            const body = {
               model: "gpt-5.1",
               temperature: 0.3,
               messages: [
-                { "role": "system", "content": "You are an experienced PR summarizer helping on GitHub pull requests." },
-                { "role": "user", "content": $prompt }
+                { role: "system", content: "You are an experienced PR summarizer helping on GitHub pull requests." },
+                { role: "user", content: prompt }
               ]
+            };
+
+            const response = await fetch('https://api.openai.com/v1/chat/completions', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`,
+                'OpenAI-Project': projectId
+              },
+              body: JSON.stringify(body)
+            });
+
+            const data = await response.json().catch(() => ({}));
+            core.info(`OpenAI response status: ${response.status}`);
+
+            let summary = 'OpenAI did not return a summary.';
+            if (data?.choices?.[0]?.message?.content) {
+              summary = data.choices[0].message.content;
+            } else if (data?.error?.message) {
+              summary = `OpenAI API error: ${data.error.message}`;
             }
-            ' > body.json
 
-          # Make API request (project is passed via header)
-          RESPONSE=$(curl -s -X POST "https://api.openai.com/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "OpenAI-Project: $OPENAI_PROJECT_ID" \
-            --data @body.json)
-
-          echo "Raw response:"
-          echo "$RESPONSE"
-
-          # Extract review text or error
-          SUMMARY=$(echo "$RESPONSE" | jq -r '
-            if .choices and .choices[0].message and .choices[0].message.content then
-              .choices[0].message.content
-            elif .error and .error.message then
-              "OpenAI API error: " + .error.message
-            else
-              "OpenAI did not return a summary."
-            end
-          ')
-
-          echo "Summary content:"
-          echo "$SUMMARY"
-
-          # Write multi-line output for GitHub Actions
-          {
-            echo 'summary<<EOF'
-            printf '%s\n' "$SUMMARY"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+            core.setOutput('summary', summary);
 
       - name: Update PR Description
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUMMARY_BODY: ${{ steps.openai.outputs.summary }}
-        run: |
-          PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")
+        with:
+          script: |
+            const fs = require('fs');
 
-          NEW_BODY="${SUMMARY_BODY}"
+            const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+            const prNumber = event.pull_request.number;
+            const summary = process.env.SUMMARY_BODY || '';
 
-          # Build the update JSON safely with jq
-          jq -n --arg body "$NEW_BODY" '{body: $body}' > update.json
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              body: summary
+            });
 
-          curl -s -X PATCH \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-            -d @update.json


### PR DESCRIPTION
## Summary (what & why):
- Switches the PR auto-summarization workflow from custom bash + curl + jq to `actions/github-script`, using Node/JS to call the OpenAI API and update PR descriptions.
- Adds more robust handling of missing OpenAI secrets and API errors, surfacing clear messages back into the PR body.
- Aligns frontend test tooling by downgrading `@testing-library/react` from `16.3.2` to `16.3.0`, likely to resolve compatibility or stability issues.

## Scope (what areas are affected):
- GitHub Actions:
  - `pr_summary.yaml` workflow for generating and posting PR summaries.
- Frontend tooling:
  - NPM dependencies for React testing (`@testing-library/react`) in `package.json` and `package-lock.json`.

## Behavior Changes (user-visible or API-visible):
- On PRs:
  - The PR description is now updated via `actions/github-script` instead of manual `curl`, but the visible outcome remains: a generated AI summary replaces the PR body.
  - If OpenAI credentials are missing or the API errors, the PR body will clearly state the issue (e.g., “Missing OPENAI_API_KEY secret.” or “OpenAI API error: …”) instead of failing silently.
- Frontend development/testing:
  - Tests that rely on `@testing-library/react` will now run against version `16.3.0` instead of `16.3.2`, which may slightly change behavior or fix a regression introduced in `.2`.

## Risk & Impact (what could break / who is affected):
- CI / PR workflow:
  - If the new `github-script` usage is misconfigured (e.g., missing imports like `core`/`github`/`context`), the PR summary step could fail or not update PR descriptions.
  - Any change in the OpenAI API response shape or endpoint behavior could affect summary generation.
- Frontend tests:
  - Tests depending on newer features or bugfixes from `@testing-library/react@16.3.2` might fail or behave differently on `16.3.0`.
  - Lockfile changes can cause different transitive dependencies to be installed, potentially impacting local dev/test environments.

## Suggested Verification (quick checks):
- Open a test PR and confirm:
  - The workflow runs successfully.
  - The PR description is replaced with a structured summary in the expected section format.
  - Missing or invalid OpenAI secrets result in a clear, human-readable message in the PR body, not a workflow crash.
- Inspect workflow logs:
  - Ensure the OpenAI call logs a status and that the `summary` output is correctly set.
- Frontend:
  - Run `npm install` in `frontend` and then `npm test` to confirm all tests still pass with `@testing-library/react@16.3.0`.
  - Spot-check a few key React component tests for expected behavior (rendering, events, assertions).

## Follow-ups (nice-to-do, not required for merge):
- Add basic error formatting in the summary (e.g., a short header) when the OpenAI API fails, so PR authors can quickly see that summarization failed.
- Add a small unit or integration test (or dry-run workflow) to validate the `github-script` logic for reading `pr.diff` and updating PRs.
- Document in CONTRIBUTING or README how the PR summary bot works and what secrets are required.