### PR TITLE
Bump react-router-dom from 6.30.0 to 7.12.0 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "axios": "^1.13.2",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "react-router-dom": "^6.30.0",
+        "react-router-dom": "^7.12.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^5.1.0"
       },
@@ -3291,15 +3291,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13419,35 +13410,51 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
-      "license": "MIT",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
-      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
-      "license": "MIT",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
+        "react-router": "7.12.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-scripts": {
@@ -14355,6 +14362,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18956,11 +18968,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
-    },
-    "@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -26052,20 +26059,27 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "requires": {
-        "@remix-run/router": "1.23.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+          "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
+        }
       }
     },
     "react-router-dom": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
-      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "requires": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
+        "react-router": "7.12.0"
       }
     },
     "react-scripts": {
@@ -26708,6 +26722,11 @@
         "parseurl": "~1.3.3",
         "send": "0.19.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "axios": "^1.13.2",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "react-router-dom": "^6.30.0",
+    "react-router-dom": "^7.12.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^5.1.0"
   },


### PR DESCRIPTION
## 📌 Summary (what & why):
- Removed the inlined Dependabot-specific jobs from the main CI workflow and moved auto-merge logic into a standalone workflow triggered after CI completes.
- Tightened the auto-merge workflow so it:
  - Resolves the PR associated with a completed CI run.
  - Only acts on Dependabot PRs.
  - Auto-approves and enables auto-merge for patch/minor updates.
  - Uses OpenAI to generate and post a structured summary comment for major dependency updates when secrets are available.
- Upgraded the frontend routing stack from `react-router-dom` 6.x to 7.12.0 (and corresponding `react-router`), aligning with newer React versions and router APIs.

## 📂 Scope (what areas are affected):
- GitHub Actions:
  - `.github/workflows/continuous_integration.yaml`
  - `.github/workflows/dependabot_auto_merge.yml`
- Frontend dependencies:
  - `frontend/package.json`
  - `frontend/package-lock.json`
- Project documentation:
  - `CHANGELOG.md` (entry for 2026-01-21 removed)

## 🔄 Behavior Changes (user-visible or API-visible):
- CI / GitHub:
  - Dependabot PRs are now handled by a separate “Auto Merge” workflow that runs after the “Continuous Integration” workflow completes successfully.
  - For Dependabot patch/minor updates:
    - PRs are automatically approved.
    - GitHub auto-merge is enabled (subject to branch protection and mergeability).
  - For Dependabot major updates:
    - A detailed, AI-generated risk/impact summary is posted as a PR comment when OpenAI secrets are configured; if secrets are missing, a simple “missing secrets” message is used instead.
  - The previous behavior of posting `@codex review` comments on failed Dependabot tests has been removed.
- Frontend:
  - The app now depends on `react-router-dom@^7.12.0` / `react-router@7.12.0`, which may change routing behavior, APIs, and minimum Node/React expectations (e.g., Node >= 20, React >= 18).

## ⚠️ Risk & Impact (what could break / who is affected):
- GitHub Actions:
  - Misconfiguration in the `workflow_run`-based trigger or PR resolution logic could result in:
    - Dependabot PRs not being auto-approved/auto-merged when expected.
    - The auto-merge workflow failing when a CI run is not associated with a PR.
  - Auto-merge GraphQL mutation assumes the PR is mergeable and that the token has sufficient permissions; failures here will block auto-merge but not code.
  - Removal of the `@codex review` failure comment may affect any external process relying on that mention.
- Frontend:
  - `react-router-dom` 7 is a major version bump; if the codebase still uses deprecated/changed APIs from v6, navigation, route rendering, or hooks could break at runtime.
  - New Node engine requirements (>= 20) might break local dev or CI environments still on older Node versions.
  - Subtle behavior changes in routing (e.g., data APIs, navigation semantics) could impact URL handling, redirects, or protected routes.

## 🔎 Suggested Verification (quick checks):
- GitHub Actions:
  - Open a test Dependabot PR (patch/minor) and confirm:
    - “Continuous Integration” runs and passes.
    - The “Auto Merge” workflow triggers afterward.
    - The PR gets an approval review and auto-merge is enabled.
  - Open a test Dependabot PR with a major version bump and confirm:
    - The “Auto Merge” workflow runs.
    - A summary comment is posted; verify content when OpenAI secrets are present and fallback behavior when they are not.
  - Confirm that non-Dependabot PRs are unaffected (no auto-approval/auto-merge).
- Frontend:
  - Run `npm install` / `npm ci` with the current Node version and ensure no engine/peer dependency errors.
  - Start the dev server and manually test:
    - Initial load of the app’s main routes.
    - Navigation between key pages (dashboard, auth flows, settings, any nested routes).
    - Behavior of protected routes, redirects, and 404 handling.
  - Run the frontend test suite (if present) to catch routing regressions.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Add or update documentation for maintainers describing:
  - How the new Auto Merge workflow behaves.
  - How to configure or rotate OpenAI secrets.
- Add automated tests (or a dry-run workflow) for the auto-merge logic to detect regressions in PR resolution or GraphQL calls.
- Review the frontend routing code for compatibility with `react-router-dom` 7 (e.g., updated APIs, data routers, loaders/actions) and adjust patterns proactively rather than relying solely on runtime errors.
- Reintroduce or replace the removed `@codex review` behavior if that signal is still desired, possibly via a more generic failure-notification workflow.