### PR TITLE
Serialize lint auto-commit jobs to avoid push conflicts

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -38,9 +38,7 @@ function App() {
   return (
     <React.Fragment>
       <Router>
-        <MyAppBar appBarHeader={
-          appBarHeader
-        } setDrawerOpen={setDrawerOpen} />
+        <MyAppBar appBarHeader={appBarHeader} setDrawerOpen={setDrawerOpen} />
         <MyDrawer
           open={drawerOpen}
           setDrawerOpen={setDrawerOpen}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds concurrency configuration to the frontend and backend lint GitHub Actions jobs.
- Ensures that lint jobs for the same ref (branch/PR) are grouped together without canceling in-progress runs.
- Aims to better control how many lint workflows run concurrently per ref, likely to reduce redundant parallel runs while preserving full execution history.

## 📂 Scope (what areas are affected):
- GitHub Actions CI:
  - Frontend lint job
  - Backend lint job

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct user- or API-visible changes in the application itself.
- CI behavior change:
  - Lint workflows for the same ref now share a concurrency group (`lint-commit-${{ github.ref }}`).
  - New lint runs for the same ref will wait rather than run in parallel with existing ones, but existing runs will not be auto-canceled.

## ⚠️ Risk & Impact (what could break / who is affected):
- Developers may notice:
  - Slower feedback if multiple lint workflows are triggered in quick succession on the same branch, since they will serialize per ref.
- Potential for confusion if people expect newer pushes to cancel older lint runs; this configuration explicitly keeps older runs alive.

## 🔎 Suggested Verification (quick checks):
- Push multiple commits in quick succession to the same branch and confirm:
  - Only one lint job per ref runs at a time for frontend and backend.
  - Earlier lint runs are not canceled when a new one starts.
- Confirm that lint results still appear correctly in the PR checks UI.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Re-evaluate whether `cancel-in-progress` should be `true` to prioritize latest commits and speed up feedback loops.
- Document CI concurrency behavior in CONTRIBUTING or a short CI guide so contributors know what to expect.