### PR TITLE
GitHub actions 17

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -41,6 +41,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: lint-commit-${{ github.ref }}
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: frontend
@@ -103,6 +106,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: lint-commit-${{ github.ref }}
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: backend


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds concurrency configuration to the frontend and backend lint GitHub Actions jobs.
- Ensures that lint jobs for the same ref (branch/commit) are grouped together without canceling in-progress runs.
- Aims to better control how many lint workflows run in parallel per ref, likely to reduce redundant runs or resource contention while still allowing current jobs to finish.

## 📂 Scope (what areas are affected):
- GitHub Actions CI:
  - Frontend lint workflow job
  - Backend lint workflow job

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct user- or API-visible changes in the application itself.
- CI behavior change:
  - Lint jobs for the same `github.ref` are now part of a concurrency group named `lint-commit-<ref>`.
  - In-progress lint jobs for a given ref will not be auto-canceled by newer ones.

## ⚠️ Risk & Impact (what could break / who is affected):
- Developers and CI maintainers:
  - If many pushes happen to the same ref in quick succession, multiple lint jobs may still run (since `cancel-in-progress: false`), which could increase CI queue time or resource usage.
  - Misconfiguration of concurrency groups could cause unexpected queuing or delays, but the change is minimal and localized.

## 🔎 Suggested Verification (quick checks):
- Push multiple commits to the same branch in quick succession and confirm:
  - Lint jobs are grouped under the same concurrency group name.
  - Earlier lint jobs are not canceled when later ones start.
- Confirm that lint jobs still execute successfully for both frontend and backend when their respective paths change.

## ➕ Follow-ups (nice-to-do, not required for merge):
- Evaluate whether `cancel-in-progress: true` would be preferable to avoid redundant lint runs on outdated commits.
- Consider applying similar concurrency controls to other CI jobs (tests, builds) if beneficial.
- Add brief documentation in the repo’s contributing/CI docs explaining the concurrency behavior for lint workflows.