### PR TITLE
GitHub actions 22

### DIFF
--- a/.github/workflows/commentary.yaml
+++ b/.github/workflows/commentary.yaml
@@ -136,7 +136,7 @@ jobs:
             });
 
             const existingBody = (pr.body || '').trim();
-            if (!existingBody) {
+            if (!existingBody || existingBody.startsWith('... ')) {
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project are documented in this file.
 - Updated GitHub Actions versions to use released `actions/checkout@v4` and `actions/setup-python@v5` (and aligned setup-node to v4).
 - Reverted lint auto-commit repository scoping to avoid running outside the git root.
 - Fixed `read-versions` composite action outputs and reduced noisy paths-filter warnings.
-- PR summary workflow now only overwrites the PR description when it is empty; otherwise it posts the summary as a comment.
+- PR summary workflow now only overwrites the PR description when it is empty or starts with "... "; otherwise it posts the summary as a comment.
 
 ## 2026-01-24
 ### Changed


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the PR summary GitHub Action so it no longer blindly overwrites existing PR descriptions.
- New behavior: only replace the PR body when it’s effectively empty or still has the initial placeholder; otherwise, add the summary as a comment.
- Documents this behavior change in the changelog for visibility and traceability.

## 📂 Scope (what areas are affected):
- GitHub Actions workflow for PR commentary/summary generation.
- Project documentation: `CHANGELOG.md`.

## 🔄 Behavior Changes (user-visible or API-visible):
- PR authors:
  - If the PR description is empty or still starts with `"… "`, the workflow will update the PR description with the generated summary.
  - If the PR already has a substantive description, the workflow will leave it intact and instead post the generated summary as a separate PR comment.

## ⚠️ Risk & Impact (what could break / who is affected):
- Low risk; behavior is limited to GitHub PR automation.
- Potential edge cases if some teams intentionally start real descriptions with `"… "`—those would still be overwritten.
- Anyone relying on the summary being in the PR body (rather than comments) for all PRs will now see it in comments only when a description already exists.

## 🔎 Suggested Verification (quick checks):
- Open a PR with an empty description and confirm the workflow updates the PR body with the summary (no extra comment).
- Open a PR whose description starts with `"… "` and confirm it is overwritten by the summary.
- Open a PR with a normal, non-placeholder description and confirm:
  - The description is unchanged.
  - A new comment appears containing the summary.
- Confirm the workflow still runs successfully on PR events (no GitHub API errors).

## ➕ Follow-ups (nice-to-do, not required for merge):
- Make the placeholder prefix (`"... "`) configurable or documented more explicitly for contributors.
- Consider tagging or formatting the summary comment in a consistent way (e.g., a heading) to make it easy to find or parse.