### PR TITLE
naming convention changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Tests
     uses: ./.github/workflows/tests.yaml
   
-  pr-summary:
+  commentary:
     name: Commentary
     needs: [lints, tests]
     uses: ./.github/workflows/commentary.yaml

--- a/.github/workflows/commentary.yaml
+++ b/.github/workflows/commentary.yaml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  ai-review:
+  ai-summary:
     name: PR Summary
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📌 Summary (what & why):
- Renames the CI workflow job that posts PR commentary from `pr-summary` to `commentary` in the main CI pipeline.
- Renames the underlying job in `commentary.yaml` from `ai-review` to `ai-summary` to better reflect its purpose (summarizing PRs rather than reviewing them).
- These naming changes clarify intent and improve consistency in how the automated PR summary feature is referenced.

## 📂 Scope (what areas are affected):
- GitHub Actions CI configuration:
  - Main CI workflow (`ci.yaml`)
  - Commentary/PR summary workflow (`commentary.yaml`)

## 🔄 Behavior Changes (user-visible or API-visible):
- No functional behavior changes to CI or PR handling are introduced; only job identifiers and display names in GitHub Actions are updated.