### PR TITLE
auto retry on auto merger

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -40,13 +40,26 @@ jobs:
               return;
             }
 
-            let pr;
-            const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
-            pr = data;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-            if (!pr) {
-              core.warning('PR data not available; skipping auto-merge handling.');
-              return;
+            let pr;
+            for (let attempt = 0; attempt < 60; attempt += 1) {
+              const { data } = await github.rest.pulls.get({ owner, repo, pull_number });
+              pr = data;
+
+              if (!pr) {
+                core.warning('PR data not available; skipping auto-merge handling.');
+                return;
+              }
+
+              if (pr.mergeable !== null && pr.mergeable_state !== 'unknown') {
+                break;
+              }
+
+              if (attempt < 59) {
+                core.info('Mergeability not ready yet; retrying in 5 seconds.');
+                await sleep(5000);
+              }
             }
 
             if (pr.merged || pr.draft) {


### PR DESCRIPTION
## 📌 Summary (what & why):

- Adds retry logic to the auto-merge GitHub Action so it waits for GitHub to finish computing PR mergeability before deciding whether to auto-merge. This reduces flaky “unknown mergeability” behavior.
- Renames CI workflow job identifiers to be clearer and more aligned with their purpose (PR summary / AI review).
- Adjusts backend dependencies to slightly older, presumably more stable or compatible versions of Django, DRF, SimpleJWT, CORS headers, and PyYAML.
- Aligns frontend routing dependencies (`react-router-dom`, `react-router`, `@remix-run/router`) to a consistent 6.30.0 / 1.23.0 set, likely to avoid regressions or incompatibilities introduced in .3/.2 patch versions.

## 📂 Scope (what areas are affected):

- GitHub Actions:
  - Auto-merge workflow behavior.
  - CI workflow job naming and PR-summary workflow.
- Backend:
  - Python/Django dependency stack (Django, DRF, JWT auth, CORS, YAML parsing).
- Frontend:
  - Routing layer (`react-router-dom`, `react-router`, `@remix-run/router`) via `package.json` and `package-lock.json`.

## 🔄 Behavior Changes (user-visible or API-visible):

- PR auto-merge:
  - The bot now polls up to ~5 minutes for `mergeable` / `mergeable_state` to become known before proceeding, reducing skipped or incorrect auto-merge decisions when GitHub is slow to compute mergeability.
- Backend:
  - No intentional functional changes are implied, but downgrading core libraries can subtly affect behavior (e.g., bugfixes or new features from the newer versions will no longer be present). This may restore compatibility with existing code or dependencies that weren’t ready for the latest releases.
- Frontend:
  - Routing behavior should remain effectively the same; the change is a minor version step back within the same major version. It may fix issues introduced by the newer patch versions or avoid breaking changes, but no new routing features from 6.30.3/1.23.2 will be available.