### PR TITLE
added more context to the pr-reviewer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,18 @@ jobs:
   commentary:
     name: Commentary
     needs: [lints, tests]
+    if: always()
     uses: ./.github/workflows/commentary.yaml
     secrets: inherit
+    with:
+      lint_frontend_status: ${{ needs.lints.outputs.lint_frontend_status }}
+      lint_frontend_log: ${{ needs.lints.outputs.lint_frontend_log }}
+      lint_backend_status: ${{ needs.lints.outputs.lint_backend_status }}
+      lint_backend_log: ${{ needs.lints.outputs.lint_backend_log }}
+      test_frontend_status: ${{ needs.tests.outputs.test_frontend_status }}
+      test_frontend_log: ${{ needs.tests.outputs.test_frontend_log }}
+      test_backend_status: ${{ needs.tests.outputs.test_backend_status }}
+      test_backend_log: ${{ needs.tests.outputs.test_backend_log }}
 
   auto-merge:
     name: Auto Merge

--- a/.github/workflows/commentary.yaml
+++ b/.github/workflows/commentary.yaml
@@ -2,6 +2,39 @@ name: Commentary
 
 on:
   workflow_call:
+    inputs:
+      lint_frontend_status:
+        description: Frontend lint status (success/failure/none).
+        required: false
+        type: string
+      lint_frontend_log:
+        description: Frontend lint log tail.
+        required: false
+        type: string
+      lint_backend_status:
+        description: Backend lint status (success/failure/none).
+        required: false
+        type: string
+      lint_backend_log:
+        description: Backend lint log tail.
+        required: false
+        type: string
+      test_frontend_status:
+        description: Frontend test status (success/failure/none).
+        required: false
+        type: string
+      test_frontend_log:
+        description: Frontend test log tail.
+        required: false
+        type: string
+      test_backend_status:
+        description: Backend test status (success/failure/none).
+        required: false
+        type: string
+      test_backend_log:
+        description: Backend test log tail.
+        required: false
+        type: string
 
 concurrency:
   group: commentary-${{ github.ref }}
@@ -128,6 +161,20 @@ jobs:
             - Max 6 inline comments. If none, return an empty comments array.
             - If issues are critical, use REQUEST_CHANGES; if no issues, APPROVE; otherwise COMMENT.
             - If the diff is truncated, mention it in the body.
+
+            CI context (lint/test results):
+            - lint_frontend_status: ${{ inputs.lint_frontend_status || 'none' }}
+            - lint_backend_status: ${{ inputs.lint_backend_status || 'none' }}
+            - test_frontend_status: ${{ inputs.test_frontend_status || 'none' }}
+            - test_backend_status: ${{ inputs.test_backend_status || 'none' }}
+            - lint_frontend_log (tail):
+            ${{ inputs.lint_frontend_log }}
+            - lint_backend_log (tail):
+            ${{ inputs.lint_backend_log }}
+            - test_frontend_log (tail):
+            ${{ inputs.test_frontend_log }}
+            - test_backend_log (tail):
+            ${{ inputs.test_backend_log }}
 
             Here is the line-numbered diff:
 

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -7,6 +7,19 @@ on:
         description: "Branch or ref to check out for auto-fix commits."
         required: false
         type: string
+    outputs:
+      lint_frontend_status:
+        description: Frontend lint status (success/failure/none).
+        value: ${{ jobs.lint-frontend.outputs.status }}
+      lint_frontend_log:
+        description: Frontend lint log tail.
+        value: ${{ jobs.lint-frontend.outputs.log }}
+      lint_backend_status:
+        description: Backend lint status (success/failure/none).
+        value: ${{ jobs.lint-backend.outputs.status }}
+      lint_backend_log:
+        description: Backend lint log tail.
+        value: ${{ jobs.lint-backend.outputs.log }}
 
 concurrency:
   group: lint-${{ github.ref }}
@@ -95,11 +108,46 @@ jobs:
           commit_user_name: "lint-bot"
           commit_user_email: "lint-bot@users.noreply.github.com"
 
-      - name: Prettier (check only)
-        run: npm run format:check
+      - name: Lint checks
+        id: lint_checks
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          status=0
+          npm run format:check 2>&1 | tee lint_output.txt || status=$?
+          npm run lint:strict 2>&1 | tee -a lint_output.txt || status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
 
-      - name: ESLint (no warnings)
-        run: npm run lint:strict
+      - name: Lint summary
+        id: lint_summary
+        if: always()
+        run: |
+          exit_code="${{ steps.lint_checks.outputs.exit_code }}"
+          if [ -z "$exit_code" ]; then
+            exit_code=1
+          fi
+          if [ "$exit_code" = "0" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo 'log<<EOF'
+            if [ -f lint_output.txt ]; then
+              tail -n 200 lint_output.txt
+            else
+              echo "No lint output captured."
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fail if lint failed
+        if: steps.lint_checks.outputs.exit_code != '0'
+        run: exit 1
+    outputs:
+      status: ${{ steps.lint_summary.outputs.status }}
+      log: ${{ steps.lint_summary.outputs.log }}
 
   lint-backend:
     name: Lint Backend (Ruff)
@@ -160,8 +208,43 @@ jobs:
           commit_user_name: "lint-bot"
           commit_user_email: "lint-bot@users.noreply.github.com"
 
-      - name: Ruff (check only)
-        run: ruff check .
+      - name: Ruff checks
+        id: lint_checks
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          status=0
+          ruff check . 2>&1 | tee lint_output.txt || status=$?
+          ruff format --check . 2>&1 | tee -a lint_output.txt || status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
 
-      - name: Ruff format (check only)
-        run: ruff format --check .
+      - name: Lint summary
+        id: lint_summary
+        if: always()
+        run: |
+          exit_code="${{ steps.lint_checks.outputs.exit_code }}"
+          if [ -z "$exit_code" ]; then
+            exit_code=1
+          fi
+          if [ "$exit_code" = "0" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo 'log<<EOF'
+            if [ -f lint_output.txt ]; then
+              tail -n 200 lint_output.txt
+            else
+              echo "No lint output captured."
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fail if lint failed
+        if: steps.lint_checks.outputs.exit_code != '0'
+        run: exit 1
+    outputs:
+      status: ${{ steps.lint_summary.outputs.status }}
+      log: ${{ steps.lint_summary.outputs.log }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,19 @@ name: Tests
 
 on:
   workflow_call:
+    outputs:
+      test_frontend_status:
+        description: Frontend test status (success/failure/none).
+        value: ${{ jobs.frontend-tests.outputs.status }}
+      test_frontend_log:
+        description: Frontend test log tail.
+        value: ${{ jobs.frontend-tests.outputs.log }}
+      test_backend_status:
+        description: Backend test status (success/failure/none).
+        value: ${{ jobs.backend-tests.outputs.status }}
+      test_backend_log:
+        description: Backend test log tail.
+        value: ${{ jobs.backend-tests.outputs.log }}
 
 concurrency:
   group: tests-${{ github.ref }}
@@ -33,9 +46,46 @@ jobs:
         run: npm ci
 
       - name: Run frontend tests
+        id: test_run
+        continue-on-error: true
         env:
           CI: true
-        run: npm test -- --watchAll=false --verbose --runInBand
+        run: |
+          set -o pipefail
+          status=0
+          npm test -- --watchAll=false --verbose --runInBand 2>&1 | tee test_output.txt || status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Test summary
+        id: test_summary
+        if: always()
+        run: |
+          exit_code="${{ steps.test_run.outputs.exit_code }}"
+          if [ -z "$exit_code" ]; then
+            exit_code=1
+          fi
+          if [ "$exit_code" = "0" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo 'log<<EOF'
+            if [ -f test_output.txt ]; then
+              tail -n 200 test_output.txt
+            else
+              echo "No test output captured."
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fail if tests failed
+        if: steps.test_run.outputs.exit_code != '0'
+        run: exit 1
+    outputs:
+      status: ${{ steps.test_summary.outputs.status }}
+      log: ${{ steps.test_summary.outputs.log }}
 
   backend-tests:
     name: Backend Tests (Django)
@@ -62,4 +112,41 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run backend tests
-        run: python manage.py test --verbosity=2
+        id: test_run
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          status=0
+          python manage.py test --verbosity=2 2>&1 | tee test_output.txt || status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Test summary
+        id: test_summary
+        if: always()
+        run: |
+          exit_code="${{ steps.test_run.outputs.exit_code }}"
+          if [ -z "$exit_code" ]; then
+            exit_code=1
+          fi
+          if [ "$exit_code" = "0" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo 'log<<EOF'
+            if [ -f test_output.txt ]; then
+              tail -n 200 test_output.txt
+            else
+              echo "No test output captured."
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fail if tests failed
+        if: steps.test_run.outputs.exit_code != '0'
+        run: exit 1
+    outputs:
+      status: ${{ steps.test_summary.outputs.status }}
+      log: ${{ steps.test_summary.outputs.log }}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds structured status and log outputs from lint and test jobs (frontend and backend) and wires them into the `commentary` workflow so PR reviews can see CI context directly.
- Refactors lint and test steps to:
  - Capture combined command output to files.
  - Derive a normalized `success`/`failure` status.
  - Expose a trimmed tail of logs as workflow outputs.
- Ensures the `commentary` job always runs (even on CI failure) and includes CI results in the prompt for the review bot, improving automated review quality and debuggability.

## 📂 Scope (what areas are affected):
- GitHub Actions workflows:
  - `ci.yaml` (job wiring and commentary invocation).
  - `commentary.yaml` (inputs and prompt content).
  - `lints.yaml` (frontend and backend lint execution, outputs).
  - `tests.yaml` (frontend and backend test execution, outputs).

## 🔄 Behavior Changes (user-visible or API-visible):
- On PRs:
  - The commentary/review bot will now always run, even if lints or tests fail.
  - Review comments will include summarized CI context: pass/fail status for each lint/test job plus the tail of their logs.
- CI behavior:
  - Lint and test jobs now:
    - Run their checks with `continue-on-error` internally, summarize results, and then explicitly fail the job if needed.
    - Expose `status` (`success`/`failure`) and a short `log` snippet as reusable workflow outputs.
- No changes to the underlying linting/testing commands themselves; only how their results are captured, surfaced, and consumed by other workflows.