### PR TITLE
update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,18 @@
 All notable changes to this project are documented in this file.
 
 ## 2026-01-25
+### Added
+- Added `backend/environment_conda_export.py` to export Conda environments with pinned versions.
 ### Changed
-- Centralized CI version detection into a reusable `read-versions` composite action for Node and Python.
-- Documented Ruff lint rules and enabled safe autofix for unused assignments via config.
-- Fixed lint workflow checkouts to use the PR head branch so auto-commit can push fixes.
-- Passed the PR head ref into lint workflows invoked via `workflow_call` to avoid detached HEAD.
-- Aligned lint auto-commit branches with the checkout ref for reusable workflow calls.
-- Skip lint auto-commit steps when no changes are detected after auto-fixes.
-- Scoped lint auto-commit actions to their respective subdirectories to ensure changes are staged.
-- Updated GitHub Actions versions to use released `actions/checkout@v4` and `actions/setup-python@v5` (and aligned setup-node to v4).
-- Reverted lint auto-commit repository scoping to avoid running outside the git root.
-- Fixed `read-versions` composite action outputs and reduced noisy paths-filter warnings.
-- PR summary workflow now only overwrites the PR description when it is empty or starts with "... "; otherwise it posts the summary as a comment.
-- Added Dependabot pip updates for the backend.
-- PR summary workflow now only overwrites the PR description when it is empty or starts with "..."; otherwise it posts the summary as a comment.
+- CI lint/test workflows now pin Node 18.20.8 and Python 3.12 via setup-node/setup-python v6 and no longer use `read-versions` or `checkout_ref`.
+- Lint auto-fix commits now target `github.head_ref` and scope file patterns to `frontend/**/*` and `backend/**/*`.
+- Backend env management now uses conda-pinned deps in `environment.yml`; tests install backend deps via explicit pip pins; Dockerfile installs from `environment.yml` only.
+- PR summary workflow now always updates the PR description (no comment fallback).
+- Frontend ESLint now extends Prettier; `eslint-config-prettier` moved to devDependencies; axios pinned to 1.13.2; icon imports consolidated.
+- Updated AGENTS maintenance instructions for the new env export script.
 ### Removed
-- Removed the Risk & Impact, Suggested Verification, and Follow-ups sections from the PR summary format.
+- Removed `read-versions`, `backend/environment_manager.py`, and `backend/requirements.txt` (pip section removed from `environment.yml`).
+- Removed the frontend ESLint config test and the Node engines field from `package.json`.
 
 ## 2026-01-24
 ### Changed


### PR DESCRIPTION
## 📌 Summary (what & why):
- Introduces a new Conda environment export script to reliably capture fully pinned backend dependencies.
- Simplifies and hard-pins CI runtimes (Node 18.20.8, Python 3.12) and removes the previous dynamic version-detection (`read-versions`) approach.
- Aligns backend dependency management around Conda (`environment.yml`) and explicit pins for tests and Docker builds, reducing drift between local, CI, and container environments.
- Adjusts lint auto-fix behavior to commit directly to the PR’s head branch and only within frontend/backend paths, making automated fixes safer and more predictable.
- Changes the PR summary workflow to always overwrite the PR description, standardizing how summaries are surfaced.
- Tightens frontend tooling by integrating Prettier into ESLint, cleaning up dependencies, pinning axios, and consolidating icon imports for consistency and maintainability.
- Updates internal AGENTS maintenance docs to reflect the new environment export process and tooling changes.

## 📂 Scope (what areas are affected):
- CI workflows for linting and testing (Node/Python setup, auto-fix commit behavior).
- Backend environment and dependency management (Conda `environment.yml`, Docker build, test installs).
- Frontend tooling and dependencies (ESLint + Prettier integration, axios, icon imports).
- GitHub PR summary automation behavior.
- Internal maintenance documentation (AGENTS instructions).

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct end-user feature changes are indicated.
- CI behavior is more deterministic:
  - Always uses Node 18.20.8 and Python 3.12.
  - Lint auto-fix commits land on the PR’s head branch and only touch `frontend/**/*` and `backend/**/*`.
- PRs will now have their description consistently overwritten by the PR summary workflow instead of sometimes receiving a separate comment.