### PR TITLE
Pushing CI/CD to Prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - env-prod
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      OWNER_LOWER: ${{ toLower(github.repository_owner) }}
+      BACKEND_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/notoli-backend
+      FRONTEND_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/notoli-frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.BACKEND_IMAGE }}:latest
+            ${{ env.BACKEND_IMAGE }}:sha-${{ github.sha }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:latest
+            ${{ env.FRONTEND_IMAGE }}:sha-${{ github.sha }}
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script: |
+            set -e
+            cd "${{ secrets.DEPLOY_PATH }}"
+            docker compose pull
+            docker compose up -d --remove-orphans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-01-27
+### Added
+- Added a production deploy workflow that builds/pushes backend and frontend images to GHCR and deploys via SSH on `env-prod`.
+### Changed
+- PR review inline comment validation now uses GitHub PR patches to avoid invalid line errors.
+
 ## 2026-01-26
 ### Changed
 - Dependabot auto-merge now also allows CVSS-based auto-merge for low-severity security alerts (while keeping patch/minor auto-merge).


### PR DESCRIPTION
## 📌 Summary (what & why):
- Introduces an automated production deployment workflow that builds Docker images for the backend and frontend, pushes them to GitHub Container Registry (GHCR), and deploys them to a remote server over SSH when changes land on the `env-prod` branch or when manually triggered.
- Documents this new deployment pipeline in the changelog.
- Notes an internal change (already implemented elsewhere) where PR review inline comment validation now relies on GitHub PR patches to reduce “invalid line” errors.

## 📂 Scope (what areas are affected):
- CI/CD infrastructure via GitHub Actions (new `Deploy` workflow).
- Docker-based build and release process for both backend and frontend images.
- Production deployment environment reachable via SSH and `docker compose`.
- Project documentation (changelog).

## 🔄 Behavior Changes (user-visible or API-visible):
- Deployments to the production environment can now be triggered automatically on pushes to `env-prod` or manually via the GitHub Actions UI, resulting in:
  - Fresh backend and frontend images built and tagged (`latest` and `sha-<commit>`).
  - Remote server pulling updated images and restarting services via `docker compose up -d --remove-orphans`.
- PR reviewers and contributors should see fewer failures when leaving inline comments on diffs, thanks to more robust line/patch validation (behavioral improvement in the review tooling, not the app itself).