### PR TITLE
Pass CRA API base URL into frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,8 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
+          build-args: |
+            REACT_APP_API_BASE_URL=${{ secrets.REACT_APP_API_BASE_URL }}
           tags: |
             ${{ steps.image_names.outputs.frontend_image }}:latest
             ${{ steps.image_names.outputs.frontend_image }}:sha-${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-01-31
+### Changed
+- Frontend Docker build now accepts CRA `REACT_APP_API_BASE_URL` as a build-time arg.
+- Deploy workflow passes the CRA API base URL secret into the frontend image build.
+
 ## 2026-01-26
 ### Changed
 - Dependabot auto-merge now also allows CVSS-based auto-merge for low-severity security alerts (while keeping patch/minor auto-merge).

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,10 @@ RUN npm install
 # Copy your React project code
 COPY . .
 
+# Build-time envs for CRA
+ARG REACT_APP_API_BASE_URL
+ENV REACT_APP_API_BASE_URL=$REACT_APP_API_BASE_URL
+
 # Build optimized React app (outputs to /frontend/build)
 RUN npm run build
 


### PR DESCRIPTION
## 📌 Summary (what & why):
- Wire up a build-time configuration for the frontend so the React app can receive `REACT_APP_API_BASE_URL` from GitHub Secrets during Docker image builds, aligning the deployed frontend with the correct backend API endpoint.
- Document this deployment/configuration behavior in the changelog.
- Adjust the SSH deploy action version in the workflow (likely for compatibility or stability).
- Slightly downgrade `axios` in the frontend dependencies, likely to avoid a regression or incompatibility introduced in `1.13.4`.

## 📂 Scope (what areas are affected):
- GitHub Actions deploy workflow (frontend image build and SSH deploy step).
- Frontend Docker build process and runtime environment variables.
- Frontend dependency tree (specifically `axios` version).
- Project documentation (CHANGELOG).

## 🔄 Behavior Changes (user-visible or API-visible):
- Deployed frontend instances will now have the API base URL baked in at build time via `REACT_APP_API_BASE_URL`, reducing reliance on ad-hoc runtime configuration and making environment-specific deployments (staging/prod) more predictable.
- Frontend HTTP behavior may change subtly due to the `axios` version rollback (bugfix/regression avoidance), but no intentional API contract changes are introduced in this PR.