### PR TITLE
Add deploy passphrase secret support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,14 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_PASSPHRASE: ${{ secrets.DEPLOY_PASSPHRASE }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         run: |
           missing=()
           [ -z "$DEPLOY_HOST" ] && missing+=("DEPLOY_HOST")
           [ -z "$DEPLOY_USER" ] && missing+=("DEPLOY_USER")
           [ -z "$DEPLOY_SSH_KEY" ] && missing+=("DEPLOY_SSH_KEY")
+          [ -z "$DEPLOY_PASSPHRASE" ] && missing+=("DEPLOY_PASSPHRASE")
           [ -z "$DEPLOY_PATH" ] && missing+=("DEPLOY_PATH")
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "Missing required secrets: ${missing[*]}"
@@ -95,6 +97,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          passphrase: ${{ secrets.DEPLOY_PASSPHRASE }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
           script: |
             set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Frontend Docker build now accepts CRA `REACT_APP_API_BASE_URL` as a build-time arg.
 - Deploy workflow passes the CRA API base URL secret into the frontend image build.
+- Deploy workflow now supports SSH key passphrases via `DEPLOY_PASSPHRASE`.
 
 ## 2026-01-26
 ### Changed


### PR DESCRIPTION
## 📌 Summary (what & why):
- Added support in the deploy GitHub Action for SSH keys that use a passphrase, enabling more secure deployment keys.
- Updated the deployment step to pass the SSH key passphrase into the SSH action so deployments work with passphrase-protected keys.
- Slightly downgraded the frontend `axios` dependency from `1.13.4` to `1.13.3`, likely to address compatibility or stability concerns.
- Documented the new deploy behavior in the changelog.

## 📂 Scope (what areas are affected):
- CI/CD:
  - GitHub Actions deploy workflow (`deploy.yml`)
- Frontend:
  - Dependency management (`axios` version in `package.json` / `package-lock.json`)
- Project documentation:
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- Deployments:
  - CI deployments can now use passphrase-protected SSH keys via the `DEPLOY_PASSPHRASE` secret; missing this secret will now be treated as a configuration error.
- Frontend:
  - The app now ships with `axios@1.13.3` instead of `1.13.4`; no intentional API or UX changes are implied, but behavior may differ slightly according to upstream axios changes between these versions.