### PR TITLE
Revert deploy passphrase support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,12 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          DEPLOY_PASSPHRASE: ${{ secrets.DEPLOY_PASSPHRASE }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         run: |
           missing=()
           [ -z "$DEPLOY_HOST" ] && missing+=("DEPLOY_HOST")
           [ -z "$DEPLOY_USER" ] && missing+=("DEPLOY_USER")
           [ -z "$DEPLOY_SSH_KEY" ] && missing+=("DEPLOY_SSH_KEY")
-          [ -z "$DEPLOY_PASSPHRASE" ] && missing+=("DEPLOY_PASSPHRASE")
           [ -z "$DEPLOY_PATH" ] && missing+=("DEPLOY_PATH")
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "Missing required secrets: ${missing[*]}"
@@ -97,7 +95,6 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          passphrase: ${{ secrets.DEPLOY_PASSPHRASE }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
           script: |
             set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Frontend Docker build now accepts CRA `REACT_APP_API_BASE_URL` as a build-time arg.
 - Deploy workflow passes the CRA API base URL secret into the frontend image build.
-- Deploy workflow now supports SSH key passphrases via `DEPLOY_PASSPHRASE`.
 
 ## 2026-01-26
 ### Changed


### PR DESCRIPTION
## 📌 Summary (what & why):
- Removes support for SSH key passphrases in the GitHub Actions deploy workflow, simplifying required deployment secrets.
- Pins the SSH deploy action back to `appleboy/ssh-action@v1.0.3`, likely for stability or compatibility with the current setup.
- Reverts the frontend `axios` dependency from `1.13.4` to `1.13.3`, suggesting a rollback from a problematic or unneeded upgrade.
- Updates the changelog to no longer claim passphrase support in the deploy workflow, keeping documentation accurate.

## 📂 Scope (what areas are affected):
- CI/CD:
  - GitHub Actions deploy workflow configuration.
- Frontend:
  - Dependency management for `axios` in `package.json` and `package-lock.json`.
- Documentation:
  - `CHANGELOG.md` entry for deployment behavior.

## 🔄 Behavior Changes (user-visible or API-visible):
- Deployment:
  - Deployments no longer expect or use a `DEPLOY_PASSPHRASE` secret; only key-based SSH without passphrase is supported.
  - The behavior of the SSH step is aligned with `appleboy/ssh-action@v1.0.3`, which may differ subtly from `v1.2.5` but should be transparent to end users.
- Frontend:
  - HTTP client behavior is now based on `axios@1.13.3` instead of `1.13.4`; any bugfixes/regressions introduced in `1.13.4` are rolled back, which may resolve issues seen after the upgrade.