### PR TITLE
.env fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,12 @@ jobs:
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.5
+        env:
+          DJANGO_DEBUG: ${{ secrets.DJANGO_DEBUG }}
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          DJANGO_SQLITE_PATH: ${{ secrets.DJANGO_SQLITE_PATH }}
+          DJANGO_ALLOWED_HOSTS: ${{ secrets.DJANGO_ALLOWED_HOSTS }}
+          DJANGO_CORS_ALLOWED_ORIGINS: ${{ secrets.DJANGO_CORS_ALLOWED_ORIGINS }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds Django-related environment variables (debug flag, secret key, SQLite path, allowed hosts, CORS origins) to the deploy step of the GitHub Actions workflow.
- Ensures the remote deployment command has access to the same configuration values stored as GitHub Secrets, improving consistency and security of the deployment process.

## 📂 Scope (what areas are affected):
- CI/CD:
  - GitHub Actions `deploy.yml` workflow
- Backend runtime configuration during deployment (Django env vars passed over SSH)

## 🔄 Behavior Changes (user-visible or API-visible):
- (none)