### PR TITLE
testing backend permanence

### DIFF
--- a/frontend/src/pages/authentication/Login.js
+++ b/frontend/src/pages/authentication/Login.js
@@ -79,7 +79,7 @@ export default function Login({ showSnackbar }) {
       }}
     >
       <Typography variant="h3" sx={{ mt: 2, fontWeight: 'bold', color: 'white' }}>
-        notoli
+        testing backend permanence
       </Typography>
       <Paper
         elevation={3}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Updated the login page header text from the project name ("notoli") to "testing backend permanence".
- This appears to be a temporary or experimental change, likely used to verify that frontend changes are being served correctly or to test backend/hosting persistence.

## 📂 Scope (what areas are affected):
- Frontend login page UI (authentication screen header text).

## 🔄 Behavior Changes (user-visible or API-visible):
- Users will now see the text "testing backend permanence" as the main title on the login page instead of "notoli".