### PR TITLE
path changes

### DIFF
--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -9,10 +9,10 @@ dependencies:
       - -r requirements.txt
 
 # Update env + requirements.txt (pip packages go into requirements.txt)
-# `python C:/Users/jaala/OneDrive/Documents/Github/Notoli/backend/environment_manager.py export -o C:/Users/jaala/OneDrive/Documents/Github/Notoli/backend/environment.yml`
+# `python environment_manager.py export -o environment.yml`
 # Overwrite environment from yaml
-# `conda env update --file C:/Users/jaala/OneDrive/Documents/Github/Notoli/backend/environment.yml --prune`
+# `conda env update --file environment.yml --prune`
 # Fresh create from yaml
-# `conda env create --file C:/Users/jaala/OneDrive/Documents/Github/Notoli/backend/environment.yml`
+# `conda env create --file environment.yml`
 # Note: conda will run pip and install -r requirements.txt from the pip section.
-# (requirements file written to: C:/Users/jaala/OneDrive/Documents/Github/Notoli/backend/requirements.txt)
+# (requirements file written to: requirements.txt)

--- a/backend/environment_manager.py
+++ b/backend/environment_manager.py
@@ -384,14 +384,14 @@ def cmd_export(args: argparse.Namespace) -> None:
     yaml_text = buf.getvalue().rstrip() + "\n"
 
     # Footer comment block (with *correct* commands)
-    # Use paths relative-ish for readability if under repo.
-    env_yml_display = paths.env_yml.as_posix()
-    req_display = paths.requirements_txt.as_posix()
+    # Assume user runs from the backend/ folder for brevity.
+    env_yml_display = paths.env_yml.name
+    req_display = paths.requirements_txt.name
 
     footer = (
         "\n"
         "# Update env + requirements.txt (pip packages go into requirements.txt)\n"
-        f"# `python {pathlib.Path(__file__).as_posix()} export -o {env_yml_display}`\n"
+        f"# `python {pathlib.Path(__file__).name} export -o {env_yml_display}`\n"
         "# Overwrite environment from yaml\n"
         f"# `conda env update --file {env_yml_display} --prune`\n"
         "# Fresh create from yaml\n"


### PR DESCRIPTION
## 📌 Summary (what & why):
- Simplifies the autogenerated usage instructions for managing the backend Conda environment.
- Assumes commands are run from the `backend/` directory so paths in comments are shorter and easier to copy-paste.
- Removes hard-coded, user-specific absolute paths from environment management guidance, making it more portable and repo-agnostic.

## 📂 Scope (what areas are affected):
- Backend environment configuration (`environment.yml`).
- Backend environment management helper script (`environment_manager.py`), specifically the footer it writes into `environment.yml`.

## 🔄 Behavior Changes (user-visible or API-visible):
- When `environment_manager.py export` is run, the footer comments in `environment.yml` now:
  - Show commands using just filenames (`environment.yml`, `requirements.txt`) instead of full paths.
  - Reference `python environment_manager.py ...` instead of a full filesystem path to the script.
- No runtime or API behavior changes; impact is limited to developer-facing documentation/comments.