### PR TITLE
base path changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Follow one of the setup paths below before running the app.
 6) Frontend setup:
    - `cd frontend`
    - `npm install`
-   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli/api`)
+   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli`)
    - `npm start`
 
 ## Setup (Docker)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 - Added an Nginx SPA fallback config for the frontend to support deep links/refresh-on-route.
 - Frontend Docker image now copies the custom Nginx config to serve `index.html` for client-side routes.
 - Updated login form fields to include autofill metadata for iOS/password managers.
-- Frontend router now uses the CRA public URL as a basename and defaults API calls to `/apps/notoli/api` when unset.
+- Frontend router now uses the CRA public URL as a basename and defaults API calls to `/apps/notoli` when unset.
 - Backend now trusts proxy HTTPS headers and supports configurable CSRF trusted origins.
 - Added a Docker reverse-proxy config for path-based routing under `/apps/notoli` with Cloudflare HTTPS header passthrough.
 

--- a/frontend/frontend.env
+++ b/frontend/frontend.env
@@ -1,2 +1,2 @@
 # Frontend
-REACT_APP_API_BASE_URL=/apps/notoli/api
+REACT_APP_API_BASE_URL=/apps/notoli

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli/api';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli';
 
 export async function apiFetch(path, options = {}) {
   const url = `${API_BASE_URL}${path}`;

--- a/frontend/src/services/apiClient.test.js
+++ b/frontend/src/services/apiClient.test.js
@@ -27,7 +27,7 @@ describe('apiClient', () => {
 
     await apiFetch('/path', { method: 'GET' });
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', { method: 'GET' });
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', { method: 'GET' });
   });
 
   test('when options are provided, it passes them through unchanged', async () => {
@@ -41,6 +41,6 @@ describe('apiClient', () => {
 
     await apiFetch('/path', options);
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', options);
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', options);
   });
 });


### PR DESCRIPTION
## 📌 Summary (what & why):
- Updated the frontend’s default API base URL from `/apps/notoli/api` to `/apps/notoli` to align with the current reverse-proxy/path-based routing setup.
- Refreshed documentation and changelog to reflect the new default so local setup and deployment expectations match actual behavior.
- Adjusted tests to validate the new base URL behavior and ensure the API client continues to construct correct request URLs.

## 📂 Scope (what areas are affected):
- Frontend configuration (environment variable `REACT_APP_API_BASE_URL` and its default).
- Frontend API client utility (`apiClient.js`) and its unit tests.
- Project documentation: agent setup instructions and changelog notes.

## 🔄 Behavior Changes (user-visible or API-visible):
- When `REACT_APP_API_BASE_URL` is not explicitly set, frontend API calls will now be made relative to `/apps/notoli` instead of `/apps/notoli/api`.
- Any deployment or proxy expecting requests under `/apps/notoli/api` must be updated (or the env var must be set) to avoid broken API calls.