### PR TITLE
more api path changes

### DIFF
--- a/frontend/src/services/backendClient.js
+++ b/frontend/src/services/backendClient.js
@@ -14,7 +14,7 @@ export const login = ({ email, username, password }) => {
     payload.username = username;
   }
 
-  return apiFetch('/auth/login/', {
+  return apiFetch('/api/auth/login/', {
     method: 'POST',
     headers: jsonHeaders(),
     body: JSON.stringify(payload),
@@ -31,7 +31,7 @@ export const register = ({ email, username, password }) => {
     payload.username = trimmedUsername;
   }
 
-  return apiFetch('/auth/register/', {
+  return apiFetch('/api/auth/register/', {
     method: 'POST',
     headers: jsonHeaders(),
     body: JSON.stringify(payload),

--- a/frontend/src/services/backendClient.test.js
+++ b/frontend/src/services/backendClient.test.js
@@ -30,7 +30,7 @@ describe('backendClient', () => {
   test('when login uses email, it posts the email payload', () => {
     login({ email: 'user@example.com', password: 'secret' });
 
-    expect(apiFetch).toHaveBeenCalledWith('/auth/login/', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/auth/login/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: expect.any(String),
@@ -42,7 +42,7 @@ describe('backendClient', () => {
   test('when login uses username, it posts the username payload', () => {
     login({ username: 'user1', password: 'secret' });
 
-    expect(apiFetch).toHaveBeenCalledWith('/auth/login/', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/auth/login/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: expect.any(String),
@@ -61,7 +61,7 @@ describe('backendClient', () => {
   test('when register trims inputs, it posts trimmed values', () => {
     register({ email: ' user@example.com ', username: ' user1 ', password: 'secret' });
 
-    expect(apiFetch).toHaveBeenCalledWith('/auth/register/', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/auth/register/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: expect.any(String),
@@ -77,7 +77,7 @@ describe('backendClient', () => {
   test('when register has blank username, it omits the username', () => {
     register({ email: 'user@example.com', username: '   ', password: 'secret' });
 
-    expect(apiFetch).toHaveBeenCalledWith('/auth/register/', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/auth/register/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: expect.any(String),


### PR DESCRIPTION
## 📌 Summary (what & why):
- Updated frontend auth service endpoints to include the `/api` prefix for login and registration calls.
- Adjusted corresponding unit tests to match the new endpoint paths.
- This aligns the frontend with the backend’s URL structure, likely fixing broken auth calls after a backend route change or standardizing API routing.

## 📂 Scope (what areas are affected):
- Frontend service layer for authentication (`backendClient`).
- Frontend unit tests for login and registration behavior.

## 🔄 Behavior Changes (user-visible or API-visible):
- Login and registration requests from the frontend now hit `/api/auth/login/` and `/api/auth/register/` instead of `/auth/login/` and `/auth/register/`.
- For end users, this should manifest as authentication working correctly against the updated backend routes (or being more consistent with other API calls), with no change to the UI or workflow.