### PR TITLE
nginx conf updates

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -17,7 +17,7 @@ server {
   # Backend API
   # /apps/notoli/api/* -> http://backend:8000/*
   location ^~ /apps/notoli/api/ {
-    rewrite ^/apps/notoli/api/(.*)$ /$1 break;
+    rewrite ^/apps/notoli/api/(.*)$ /api/$1 break;
     proxy_pass http://backend:8000;
 
     proxy_redirect off;


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the Nginx proxy rewrite rule for the Notoli backend API so that requests under `/apps/notoli/api/` are forwarded with an `/api/` prefix to the backend.
- This aligns the external URL structure with the backend’s expected `/api/...` routing, likely fixing mismatches or 404s when calling the API through the proxy.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration for the backend API
- Routing of `/apps/notoli/api/*` requests to the Django backend service

## 🔄 Behavior Changes (user-visible or API-visible):
- Requests to `/apps/notoli/api/<path>` will now be proxied to the backend as `/api/<path>` instead of `<path>` at the root.
- Any clients or frontend code using `/apps/notoli/api/...` should now correctly hit the backend’s `/api/...` endpoints without needing changes to their URLs.