### PR TITLE
Default frontend API base URL now points to `/apps/notoli` to avoid d…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Follow one of the setup paths below before running the app.
 6) Frontend setup:
    - `cd frontend`
    - `npm install`
-   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli/api`)
+   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli`)
    - `npm start`
 
 ## Setup (Docker)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-02-04
+### Changed
+- Default frontend API base URL now points to `/apps/notoli` to avoid double `/api` prefixes when client paths include `/api`.
+
 ## 2026-02-03
 ### Changed
 - Added an Nginx SPA fallback config for the frontend to support deep links/refresh-on-route.

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli/api';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli';
 
 export async function apiFetch(path, options = {}) {
   const url = `${API_BASE_URL}${path}`;

--- a/frontend/src/services/apiClient.test.js
+++ b/frontend/src/services/apiClient.test.js
@@ -27,7 +27,7 @@ describe('apiClient', () => {
 
     await apiFetch('/path', { method: 'GET' });
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', { method: 'GET' });
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', { method: 'GET' });
   });
 
   test('when options are provided, it passes them through unchanged', async () => {
@@ -41,6 +41,6 @@ describe('apiClient', () => {
 
     await apiFetch('/path', options);
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', options);
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', options);
   });
 });


### PR DESCRIPTION
…ouble `/api` prefixes when client paths include `/api`