### PR TITLE
Frontend API base URL defaults back to `/apps/notoli/api`, and fronte…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Follow one of the setup paths below before running the app.
 6) Frontend setup:
    - `cd frontend`
    - `npm install`
-   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli`)
+   - Optional: set `REACT_APP_API_BASE_URL` (default: `/apps/notoli/api`)
    - `npm start`
 
 ## Setup (Docker)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project are documented in this file.
 
 ## 2026-02-04
 ### Changed
-- Default frontend API base URL now points to `/apps/notoli` to avoid double `/api` prefixes when client paths include `/api`.
+- Frontend API base URL defaults back to `/apps/notoli/api`, and frontend client paths no longer include `/api` to avoid double prefixes.
 
 ## 2026-02-03
 ### Changed

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '/apps/notoli/api';
 
 export async function apiFetch(path, options = {}) {
   const url = `${API_BASE_URL}${path}`;

--- a/frontend/src/services/apiClient.test.js
+++ b/frontend/src/services/apiClient.test.js
@@ -27,7 +27,7 @@ describe('apiClient', () => {
 
     await apiFetch('/path', { method: 'GET' });
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', { method: 'GET' });
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', { method: 'GET' });
   });
 
   test('when options are provided, it passes them through unchanged', async () => {
@@ -41,6 +41,6 @@ describe('apiClient', () => {
 
     await apiFetch('/path', options);
 
-    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/path', options);
+    expect(global.fetch).toHaveBeenCalledWith('/apps/notoli/api/path', options);
   });
 });

--- a/frontend/src/services/backendClient.js
+++ b/frontend/src/services/backendClient.js
@@ -39,86 +39,86 @@ export const register = ({ email, username, password }) => {
 };
 
 export const fetchWorkspaces = (token) =>
-  apiFetch('/api/workspaces/', {
+  apiFetch('/workspaces/', {
     headers: authHeader(token),
   });
 
 export const fetchWorkspace = (workspaceId, token) =>
-  apiFetch(`/api/workspaces/${workspaceId}/`, {
+  apiFetch(`/workspaces/${workspaceId}/`, {
     headers: authHeader(token),
   });
 
 export const createWorkspace = (payload, token) =>
-  apiFetch('/api/workspaces/', {
+  apiFetch('/workspaces/', {
     method: 'POST',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const updateWorkspace = (workspaceId, payload, token) =>
-  apiFetch(`/api/workspaces/${workspaceId}/`, {
+  apiFetch(`/workspaces/${workspaceId}/`, {
     method: 'PATCH',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const deleteWorkspace = (workspaceId, token) =>
-  apiFetch(`/api/workspaces/${workspaceId}/`, {
+  apiFetch(`/workspaces/${workspaceId}/`, {
     method: 'DELETE',
     headers: jsonHeaders(token),
   });
 
 export const fetchTodoLists = (workspaceId, token) =>
-  apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
+  apiFetch(`/todolists/?workspace=${workspaceId}`, {
     headers: authHeader(token),
   });
 
 export const fetchTodoList = (todoListId, token) =>
-  apiFetch(`/api/todolists/${todoListId}/`, {
+  apiFetch(`/todolists/${todoListId}/`, {
     headers: authHeader(token),
   });
 
 export const createTodoList = (workspaceId, payload, token) =>
-  apiFetch(`/api/todolists/?workspace=${workspaceId}`, {
+  apiFetch(`/todolists/?workspace=${workspaceId}`, {
     method: 'POST',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const updateTodoList = (todoListId, payload, token) =>
-  apiFetch(`/api/todolists/${todoListId}/`, {
+  apiFetch(`/todolists/${todoListId}/`, {
     method: 'PATCH',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const deleteTodoList = (todoListId, token) =>
-  apiFetch(`/api/todolists/${todoListId}/`, {
+  apiFetch(`/todolists/${todoListId}/`, {
     method: 'DELETE',
     headers: jsonHeaders(token),
   });
 
 export const fetchNotes = (todoListId, token) =>
-  apiFetch(`/api/notes/?todo_list=${todoListId}`, {
+  apiFetch(`/notes/?todo_list=${todoListId}`, {
     headers: authHeader(token),
   });
 
 export const createNote = (todoListId, payload, token) =>
-  apiFetch(`/api/notes/?todo_list=${todoListId}`, {
+  apiFetch(`/notes/?todo_list=${todoListId}`, {
     method: 'POST',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const updateNote = (noteId, payload, token) =>
-  apiFetch(`/api/notes/${noteId}/`, {
+  apiFetch(`/notes/${noteId}/`, {
     method: 'PATCH',
     headers: jsonHeaders(token),
     body: JSON.stringify(payload),
   });
 
 export const deleteNote = (noteId, token) =>
-  apiFetch(`/api/notes/${noteId}/`, {
+  apiFetch(`/notes/${noteId}/`, {
     method: 'DELETE',
     headers: jsonHeaders(token),
   });

--- a/frontend/src/services/backendClient.test.js
+++ b/frontend/src/services/backendClient.test.js
@@ -89,7 +89,7 @@ describe('backendClient', () => {
   test('when fetching workspaces with a token, it sends the auth header', () => {
     fetchWorkspaces('token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/', {
       headers: { Authorization: 'Bearer token' },
     });
   });
@@ -97,7 +97,7 @@ describe('backendClient', () => {
   test('when fetching workspaces without a token, it omits the auth header', () => {
     fetchWorkspaces();
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/', {
       headers: {},
     });
   });
@@ -105,7 +105,7 @@ describe('backendClient', () => {
   test('when fetching a workspace, it calls the workspace endpoint', () => {
     fetchWorkspace(3, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/3/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/3/', {
       headers: { Authorization: 'Bearer token' },
     });
   });
@@ -113,7 +113,7 @@ describe('backendClient', () => {
   test('when creating a workspace, it posts JSON with auth', () => {
     createWorkspace({ name: 'Alpha' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ name: 'Alpha' }),
@@ -123,7 +123,7 @@ describe('backendClient', () => {
   test('when updating a workspace, it patches JSON with auth', () => {
     updateWorkspace(3, { name: 'Beta' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/3/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/3/', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ name: 'Beta' }),
@@ -133,7 +133,7 @@ describe('backendClient', () => {
   test('when deleting a workspace, it deletes with auth', () => {
     deleteWorkspace(3, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/workspaces/3/', {
+    expect(apiFetch).toHaveBeenCalledWith('/workspaces/3/', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
     });
@@ -142,7 +142,7 @@ describe('backendClient', () => {
   test('when fetching todo lists, it calls the workspace query endpoint', () => {
     fetchTodoLists(9, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/?workspace=9', {
+    expect(apiFetch).toHaveBeenCalledWith('/todolists/?workspace=9', {
       headers: { Authorization: 'Bearer token' },
     });
   });
@@ -150,7 +150,7 @@ describe('backendClient', () => {
   test('when fetching a todo list, it calls the todo list endpoint', () => {
     fetchTodoList(5, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/5/', {
+    expect(apiFetch).toHaveBeenCalledWith('/todolists/5/', {
       headers: { Authorization: 'Bearer token' },
     });
   });
@@ -158,7 +158,7 @@ describe('backendClient', () => {
   test('when creating a todo list, it posts JSON with auth', () => {
     createTodoList(9, { name: 'List' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/?workspace=9', {
+    expect(apiFetch).toHaveBeenCalledWith('/todolists/?workspace=9', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ name: 'List' }),
@@ -168,7 +168,7 @@ describe('backendClient', () => {
   test('when updating a todo list, it patches JSON with auth', () => {
     updateTodoList(5, { name: 'Updated' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/5/', {
+    expect(apiFetch).toHaveBeenCalledWith('/todolists/5/', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ name: 'Updated' }),
@@ -178,7 +178,7 @@ describe('backendClient', () => {
   test('when deleting a todo list, it deletes with auth', () => {
     deleteTodoList(5, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/todolists/5/', {
+    expect(apiFetch).toHaveBeenCalledWith('/todolists/5/', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
     });
@@ -187,7 +187,7 @@ describe('backendClient', () => {
   test('when fetching notes, it calls the todo list query endpoint', () => {
     fetchNotes(7, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/notes/?todo_list=7', {
+    expect(apiFetch).toHaveBeenCalledWith('/notes/?todo_list=7', {
       headers: { Authorization: 'Bearer token' },
     });
   });
@@ -195,7 +195,7 @@ describe('backendClient', () => {
   test('when creating a note, it posts JSON with auth', () => {
     createNote(7, { note: 'Hello' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/notes/?todo_list=7', {
+    expect(apiFetch).toHaveBeenCalledWith('/notes/?todo_list=7', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ note: 'Hello' }),
@@ -205,7 +205,7 @@ describe('backendClient', () => {
   test('when updating a note, it patches JSON with auth', () => {
     updateNote(2, { note: 'Updated' }, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/notes/2/', {
+    expect(apiFetch).toHaveBeenCalledWith('/notes/2/', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
       body: JSON.stringify({ note: 'Updated' }),
@@ -215,7 +215,7 @@ describe('backendClient', () => {
   test('when deleting a note, it deletes with auth', () => {
     deleteNote(2, 'token');
 
-    expect(apiFetch).toHaveBeenCalledWith('/api/notes/2/', {
+    expect(apiFetch).toHaveBeenCalledWith('/notes/2/', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
     });


### PR DESCRIPTION
…nd client paths no longer include `/api` to avoid double prefixes