### PR TITLE
Added the admin page to nginx

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -42,6 +42,20 @@ server {
     proxy_set_header X-Forwarded-Prefix /apps/notoli;
   }
 
+  # Backend Admin
+  # /apps/notoli/admin/* -> http://backend:8000/admin/*
+  location ^~ /apps/notoli/admin/ {
+    rewrite ^/apps/notoli/admin/(.*)$ /admin/$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
   # Frontend
   # /apps/notoli/* -> http://frontend:80/*
   location ^~ /apps/notoli/ {


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds a dedicated Nginx route to expose the Django admin interface for the backend under the existing `/apps/notoli` path.
- Aligns admin access with the app’s proxied URL structure, likely to support deployments behind a reverse proxy or under a subpath.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration for the Notoli deployment.
- Routing and URL rewriting for backend admin traffic.

## 🔄 Behavior Changes (user-visible or API-visible):
- Django admin is now accessible via `/apps/notoli/admin/…` instead of directly at `/admin/…` on the backend host.
- Requests to `/apps/notoli/admin/*` are transparently rewritten and proxied to `http://backend:8000/admin/*`, preserving standard proxy headers.