### PR TITLE
fixing static files

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -98,4 +98,15 @@ server {
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header X-Forwarded-Prefix /apps/notoli;
   }
+
+  # Backend Static (root /static for admin assets)
+  location ^~ /static/ {
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+  }
 }


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds a dedicated Nginx location for `/static/` to route backend static files (notably Django admin assets) through the backend service.
- Ensures admin and other backend-served static resources are correctly accessible behind the proxy, aligning with the app’s `/apps/notoli` mounting and proxy setup.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration
- Backend static asset delivery (e.g., Django admin static files)

## 🔄 Behavior Changes (user-visible or API-visible):
- Django admin and other backend static assets under `/static/` should now load correctly when accessed through the proxied deployment.
- Reduced likelihood of missing CSS/JS/images for admin or other backend static pages in production.