### PR TITLE
generalize backed routes

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -43,10 +43,9 @@ server {
     return 301 /apps/notoli/;
   }
 
-  # Backend API
-  # /apps/notoli/api/* -> http://backend:8000/api/*
-  location ^~ /apps/notoli/api/ {
-    rewrite ^/apps/notoli/api/(.*)$ /api/$1 break;
+  # All backend routes under /apps/notoli/*
+  location ^~ /apps/notoli/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
     proxy_pass http://backend:8000;
 
     proxy_redirect off;
@@ -55,58 +54,5 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header X-Forwarded-Prefix /apps/notoli;
-  }
-
-  # Backend Auth
-  # /apps/notoli/auth/* -> http://backend:8000/auth/*
-  location ^~ /apps/notoli/auth/ {
-    rewrite ^/apps/notoli/auth/(.*)$ /auth/$1 break;
-    proxy_pass http://backend:8000;
-
-    proxy_redirect off;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
-    proxy_set_header X-Forwarded-Prefix /apps/notoli;
-  }
-
-  # Backend Admin
-  # /apps/notoli/admin/* -> http://backend:8000/admin/*
-  location ^~ /apps/notoli/admin/ {
-    rewrite ^/apps/notoli/admin/(.*)$ /admin/$1 break;
-    proxy_pass http://backend:8000;
-
-    proxy_redirect /admin/ /apps/notoli/admin/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
-    proxy_set_header X-Forwarded-Prefix /apps/notoli;
-  }
-
-  # Backend Static (admin assets)
-  # /apps/notoli/static/* -> http://backend:8000/static/*
-  location ^~ /apps/notoli/static/ {
-    rewrite ^/apps/notoli/static/(.*)$ /static/$1 break;
-    proxy_pass http://backend:8000;
-
-    proxy_redirect off;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
-    proxy_set_header X-Forwarded-Prefix /apps/notoli;
-  }
-
-  # Backend Static (root /static for admin assets)
-  location ^~ /static/ {
-    proxy_pass http://backend:8000;
-
-    proxy_redirect off;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
   }
 }


### PR DESCRIPTION
## 📌 Summary (what & why):
- Consolidates multiple Nginx proxy rules for the backend into a single, generic route under `/apps/notoli/`.
- Simplifies path rewriting so any backend path after `/apps/notoli/` is forwarded directly to the Django backend root.
- Removes a separate `/static/` proxy, likely to reduce special-casing and centralize all backend access through the `/apps/notoli/` prefix.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration for the Notoli app.
- Routing for:
  - API endpoints (`/apps/notoli/api/...`)
  - Auth endpoints (`/apps/notoli/auth/...`)
  - Admin interface (`/apps/notoli/admin/...`)
  - Backend-served static assets under `/apps/notoli/...`
- Removal of direct `/static/` proxy at the Nginx root.

## 🔄 Behavior Changes (user-visible or API-visible):
- All backend-related requests now go through a single catch-all location: `/apps/notoli/<anything>` → backend `/<anything>`.
- API, auth, admin, and static routes under `/apps/notoli/` should continue to work but are now handled by one unified rule instead of separate blocks.
- Direct access to `/static/...` at the Nginx root (without `/apps/notoli/` prefix) will no longer be proxied to the backend and may break if anything relied on that path.