### PR TITLE
admin redirect fix

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -49,6 +49,7 @@ server {
     proxy_pass http://backend:8000;
 
     proxy_redirect off;
+    proxy_redirect /admin/ /apps/notoli/admin/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts Nginx proxy configuration so that responses targeting `/admin/` are redirected to `/apps/notoli/admin/`.
- This likely aligns the Django admin path with the deployed URL structure behind the proxy, fixing incorrect redirects or broken admin links when accessed through the main domain.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration for the backend service.
- Access and routing behavior for the Django admin interface in deployed environments.

## 🔄 Behavior Changes (user-visible or API-visible):
- When the backend issues redirects to `/admin/`, clients will now be redirected to `/apps/notoli/admin/` instead.
- Admin users accessing the site through the proxy should land on the correct admin URL path, improving accessibility and consistency of the admin interface.