### PR TITLE
preprune

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,7 @@ jobs:
             DJANGO_ALLOWED_HOSTS=$DJANGO_ALLOWED_HOSTS
             DJANGO_CORS_ALLOWED_ORIGINS=$DJANGO_CORS_ALLOWED_ORIGINS
             EOF
+            docker system prune -af
             docker compose pull
             docker compose up -d --remove-orphans
             docker compose up -d --force-recreate proxy


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds a `docker system prune -af` step to the deploy workflow before pulling and restarting containers.
- Intent is to aggressively clean up unused Docker resources (images, containers, networks, build cache) on the deployment host to free disk space and reduce clutter before deployment.

## 📂 Scope (what areas are affected):
- GitHub Actions deployment workflow for the backend/frontend stack.
- Docker environment on the deployment server (images, containers, networks, cache).

## 🔄 Behavior Changes (user-visible or API-visible):
- No direct user- or API-visible behavior changes.
- Operationally, deployments will now remove all unused Docker resources before pulling and recreating containers, which may:
  - Reduce risk of disk space issues during deployment.
  - Increase deployment time slightly due to re-pulling images when needed.