### PR TITLE
proxy fix

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -48,7 +48,6 @@ server {
     rewrite ^/apps/notoli/(.*)$ /$1 break;
     proxy_pass http://backend:8000;
 
-    proxy_redirect off;
     proxy_redirect /admin/ /apps/notoli/admin/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts Nginx proxy behavior for the backend by removing a blanket `proxy_redirect off;` directive.
- Keeps a specific redirect rule for `/admin/` while allowing default proxy redirect handling for other backend responses.
- Likely intended to fix or enable correct redirect URLs from the backend when accessed through the `/apps/notoli/` path.

## 📂 Scope (what areas are affected):
- Deployment / infrastructure:
  - Nginx reverse proxy configuration for the backend service.
- Indirectly affects how browser clients are redirected when interacting with backend endpoints behind `/apps/notoli/`.

## 🔄 Behavior Changes (user-visible or API-visible):
- Backend-generated redirects (other than `/admin/`) will now be processed by Nginx’s default redirect handling instead of being fully disabled.
- Users may see corrected or newly functional redirects when navigating flows that rely on HTTP 3xx responses (e.g., login/logout, form submissions that redirect).