### PR TITLE
preserve posts on admin

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -58,11 +58,11 @@ server {
 
   # Redirect Django admin root redirects back under /apps/notoli
   location = /admin {
-    return 301 /apps/notoli/admin/;
+    return 307 /apps/notoli/admin/;
   }
 
   location ^~ /admin/ {
-    return 301 /apps/notoli/admin/;
+    return 307 /apps/notoli/admin/;
   }
 
   # Serve Django static files at root (admin/DRF use /static/*)


### PR DESCRIPTION
## 📌 Summary (what & why):
- Updated Nginx redirects for the Django admin paths (`/admin` and `/admin/`) to use HTTP 307 (Temporary Redirect) instead of 301 (Moved Permanently).
- This preserves the original HTTP method and request body on redirect, which is safer for non-GET requests and avoids browsers caching a permanent redirect that might be hard to undo later.

## 📂 Scope (what areas are affected):
- Nginx proxy configuration for the Notoli deployment.
- Routing/redirect behavior for Django admin access paths.

## 🔄 Behavior Changes (user-visible or API-visible):
- Requests to `/admin` or `/admin/` are now temporarily redirected (307) to `/apps/notoli/admin/` instead of permanently redirected (301).
- Non-GET requests (e.g., POST) to these admin endpoints will retain their HTTP method and body after redirect, improving correctness for admin operations that might be initiated at the root admin path.