### PR TITLE
DJANGO_CSRF_TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
           DJANGO_CORS_ALLOWED_ORIGINS: ${{ vars.DJANGO_CORS_ALLOWED_ORIGINS }}
+          DJANGO_CSRF_TRUSTED_ORIGINS: ${{ vars.DJANGO_CSRF_TRUSTED_ORIGINS }}
         run: |
           missing=()
           [ -z "$DEPLOY_HOST" ] && missing+=("DEPLOY_HOST")
@@ -36,6 +37,7 @@ jobs:
           [ -z "$DJANGO_SECRET_KEY" ] && missing+=("DJANGO_SECRET_KEY")
           [ -z "$DJANGO_ALLOWED_HOSTS" ] && missing+=("DJANGO_ALLOWED_HOSTS")
           [ -z "$DJANGO_CORS_ALLOWED_ORIGINS" ] && missing+=("DJANGO_CORS_ALLOWED_ORIGINS")
+          [ -z "$DJANGO_CSRF_TRUSTED_ORIGINS" ] && missing+=("DJANGO_CSRF_TRUSTED_ORIGINS")
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "Missing required secrets: ${missing[*]}"
             exit 1
@@ -115,12 +117,13 @@ jobs:
           DJANGO_SQLITE_PATH: ${{ vars.DJANGO_SQLITE_PATH }}
           DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
           DJANGO_CORS_ALLOWED_ORIGINS: ${{ vars.DJANGO_CORS_ALLOWED_ORIGINS }}
+          DJANGO_CSRF_TRUSTED_ORIGINS: ${{ vars.DJANGO_CSRF_TRUSTED_ORIGINS }}
         with:
           host: ${{ vars.DEPLOY_HOST }}
           username: ${{ vars.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
-          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS
+          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS,DJANGO_CSRF_TRUSTED_ORIGINS
           script: |
             set -e
             cd "${{ vars.DEPLOY_PATH }}"
@@ -132,6 +135,7 @@ jobs:
             DJANGO_SQLITE_PATH=$DJANGO_SQLITE_PATH
             DJANGO_ALLOWED_HOSTS=$DJANGO_ALLOWED_HOSTS
             DJANGO_CORS_ALLOWED_ORIGINS=$DJANGO_CORS_ALLOWED_ORIGINS
+            DJANGO_CSRF_TRUSTED_ORIGINS=$DJANGO_CSRF_TRUSTED_ORIGINS
             EOF
             docker system prune -af
             docker compose pull


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds `DJANGO_CSRF_TRUSTED_ORIGINS` to the deployment workflow so the backend receives its CSRF configuration from GitHub environment variables.
- Ensures deployments fail fast if this new variable is missing, preventing misconfigured CSRF protection in production.

## 📂 Scope (what areas are affected):
- GitHub Actions deployment workflow (`deploy.yml`).
- Runtime environment configuration for the Django backend (CSRF-related settings).

## 🔄 Behavior Changes (user-visible or API-visible):
- CSRF protection behavior in deployed environments will now respect the `DJANGO_CSRF_TRUSTED_ORIGINS` setting, which may fix or prevent CSRF-related errors (e.g., form submissions or API POSTs from trusted frontends being rejected if previously misconfigured).