### PR TITLE
trailing slash removed

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -9,9 +9,19 @@ server {
 
   client_max_body_size 25m;
 
-  # Redirect /apps/notoli -> /apps/notoli/
+  # Frontend base (no trailing slash)
   location = /apps/notoli {
-    return 301 /apps/notoli/;
+    proxy_pass http://frontend:80;
+    proxy_http_version 1.1;
+
+    proxy_redirect off;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
   }
 
   # Frontend
@@ -38,9 +48,9 @@ server {
 
   client_max_body_size 25m;
 
-  # Redirect /apps/notoli -> /apps/notoli/
-  location = /apps/notoli {
-    return 301 /apps/notoli/;
+  # Redirect trailing slash to no-slash base
+  location = /apps/notoli/ {
+    return 301 /apps/notoli;
   }
 
   # All backend routes under /apps/notoli/*


### PR DESCRIPTION
## 📌 Summary (what & why):
- Updates the Nginx proxy configuration so that `/apps/notoli` (without trailing slash) is treated as the canonical frontend entry point instead of redirecting to `/apps/notoli/`.
- Adds a full proxy configuration for the no-slash base path, ensuring correct headers and WebSocket/HTTP/HTTPS handling.
- Reverses the redirect direction so that `/apps/notoli/` now redirects to `/apps/notoli`, standardizing URLs and likely avoiding redirect loops or path issues with the frontend.

## 📂 Scope (what areas are affected):
- Nginx reverse proxy configuration for the Notoli frontend under `/apps/notoli`.
- URL routing and canonicalization for the frontend base path.
- Request headers and connection handling between Nginx and the frontend service.

## 🔄 Behavior Changes (user-visible or API-visible):
- Navigating to `/apps/notoli/` will now redirect to `/apps/notoli` (instead of the other way around).
- Requests to `/apps/notoli` will directly serve the frontend app, with proper proxy headers and WebSocket support, which may fix issues with initial page load, routing, or authentication behind the proxy.
- Browser-visible URLs will normalize to the no-trailing-slash version for the app base path.