### PR TITLE
slash redirection

### DIFF
--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -9,6 +9,11 @@ server {
 
   client_max_body_size 25m;
 
+  # Redirect trailing slash to no-slash base
+  location = /apps/notoli/ {
+    return 301 /apps/notoli;
+  }
+
   # Frontend base (no trailing slash)
   location = /apps/notoli {
     proxy_pass http://frontend:80;


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adds an explicit nginx redirect from `/apps/notoli/` (with trailing slash) to `/apps/notoli` (no trailing slash).
- Aligns URL handling with the frontend base path expectation to avoid duplicate routes or inconsistent behavior.

## 📂 Scope (what areas are affected):
- Nginx proxy configuration for the Notoli frontend deployment.
- URL routing/redirect behavior for the `/apps/notoli` entry point.

## 🔄 Behavior Changes (user-visible or API-visible):
- Visiting `/apps/notoli/` now results in an HTTP 301 redirect to `/apps/notoli`.
- Users and clients will see a canonical, slash-less base URL, which may affect bookmarked URLs or tooling that is sensitive to redirects.