### PR TITLE
backend url changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Follow one of the setup paths below before running the app.
    - `cd frontend`
    - `npm install`
    - Optional: set `REACT_APP_API_BASE_URL` (default: `http://localhost:8000`)
-     - For production builds, set this to `https://api.judeandrewalaba.com/apps/notoli`
+     - For production builds, set this to `https://judeandrewalaba.com/apps/notoli`
    - `npm start`
 
 ## Setup (Docker)
@@ -48,4 +48,3 @@ Follow one of the setup paths below before running the app.
 - Frontend deps: `cd frontend` then `npm install`
 - Note: pip dependencies are installed via the `pip:` section in `environment.yml`
   and resolved from `requirements.txt` (never via conda).
-  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-02-06
+### Changed
+- Frontend API base URL defaults to `http://localhost:8000` for local dev; production should set `REACT_APP_API_BASE_URL` to `https://judeandrewalaba.com/apps/notoli`.
+- Nginx now serves the backend via `judeandrewalaba.com/apps/notoli/{api,auth,admin}`.
+
 ## 2026-02-04
 ### Changed
 - Frontend API base URL defaults to `http://localhost:8000` for local dev; production should set `REACT_APP_API_BASE_URL` to the API subdomain.
@@ -12,7 +17,7 @@ All notable changes to this project are documented in this file.
 - Added an Nginx SPA fallback config for the frontend to support deep links/refresh-on-route.
 - Frontend Docker image now copies the custom Nginx config to serve `index.html` for client-side routes.
 - Updated login form fields to include autofill metadata for iOS/password managers.
-- Frontend router now uses the CRA public URL as a basename and defaults API calls to `/apps/notoli/api` when unset.
+- Frontend router now uses the CRA public URL as a basename; API calls are prefixed by `REACT_APP_API_BASE_URL` (defaults to `http://localhost:8000`).
 - Backend now trusts proxy HTTPS headers and supports configurable CSRF trusted origins.
 - Added a Docker reverse-proxy config for path-based routing under `/apps/notoli` with Cloudflare HTTPS header passthrough.
 - Moved deployment assets into `deploy/`, including `docker-compose.yml` and environment files.

--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -14,6 +14,72 @@ server {
     return 301 /apps/notoli;
   }
 
+  # Backend routes (served from the same domain under /apps/notoli/*)
+  # Keep these above the frontend catch-all so they win location matching.
+  location = /apps/notoli/api { return 301 /apps/notoli/api/; }
+  location ^~ /apps/notoli/api/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
+  location = /apps/notoli/auth { return 301 /apps/notoli/auth/; }
+  location ^~ /apps/notoli/auth/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
+  location = /apps/notoli/admin { return 301 /apps/notoli/admin/; }
+  location ^~ /apps/notoli/admin/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
+  # Django admin + DRF browsable API static (avoid clobbering the frontend /apps/notoli/static/* assets)
+  location ^~ /apps/notoli/static/admin/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
+  location ^~ /apps/notoli/static/rest_framework/ {
+    rewrite ^/apps/notoli/(.*)$ /$1 break;
+    proxy_pass http://backend:8000;
+
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Prefix /apps/notoli;
+  }
+
   # Frontend base (no trailing slash)
   location = /apps/notoli {
     proxy_pass http://frontend:80;
@@ -45,30 +111,4 @@ server {
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header X-Forwarded-Prefix /apps/notoli;
   }
-}
-
-server {
-  listen 80;
-  server_name api.judeandrewalaba.com;
-
-  client_max_body_size 25m;
-
-  # Redirect trailing slash to no-slash base
-  location = /apps/notoli/ {
-    return 301 /apps/notoli;
-  }
-
-  # All backend routes under /apps/notoli/*
-  location ^~ /apps/notoli/ {
-    rewrite ^/apps/notoli/(.*)$ /$1 break;
-    proxy_pass http://backend:8000;
-
-    proxy_redirect off;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
-    proxy_set_header X-Forwarded-Prefix /apps/notoli;
-  }
-
 }


### PR DESCRIPTION
## 📌 Summary (what & why):
- Consolidates deployment so the backend is now served from the main domain (`judeandrewalaba.com/apps/notoli/...`) instead of a separate `api.` subdomain, simplifying hosting and routing.
- Updates documentation and changelog to reflect the new production API base URL and path-based routing.
- Adjusts the Nginx reverse-proxy configuration so that `/apps/notoli/{api,auth,admin}` and related backend static assets are correctly routed to Django, while the SPA frontend continues to serve everything else.
- Tweaks frontend lockfile dependencies (notably Webpack and related tooling) to a slightly older but compatible set of versions, likely to resolve build or compatibility issues.

## 📂 Scope (what areas are affected):
- Deployment & infrastructure:
  - Nginx reverse-proxy configuration under `deploy/nginx-proxy.conf`.
  - Domain and path structure for backend endpoints.
- Documentation:
  - `AGENTS.md` setup instructions for production frontend API base URL.
  - `CHANGELOG.md` entry for the new routing and base URL behavior.
- Frontend build tooling:
  - `frontend/package-lock.json` (Webpack, browserslist, jsonpath, static-eval, underscore, etc.).

## 🔄 Behavior Changes (user-visible or API-visible):
- Production URLs:
  - Backend is now accessed via `https://judeandrewalaba.com/apps/notoli/api`, `/auth`, `/admin` (plus their trailing-slash variants) instead of `https://api.judeandrewalaba.com/...`.
  - Frontend production builds should set `REACT_APP_API_BASE_URL` to `https://judeandrewalaba.com/apps/notoli`.
- Routing behavior:
  - Requests to `/apps/notoli/api`, `/apps/notoli/auth`, and `/apps/notoli/admin` are 301-redirected to include a trailing slash, then proxied to the Django backend.
  - Backend static assets for Django admin and DRF (`/apps/notoli/static/admin/`, `/apps/notoli/static/rest_framework/`) are explicitly routed to the backend so they don’t conflict with frontend static assets.
  - All other `/apps/notoli` paths continue to be served by the frontend SPA via Nginx.
- Build behavior:
  - Frontend build may change slightly due to the adjusted Webpack and related dependency versions, but no intentional user-facing UI changes are implied.