### PR TITLE
removed some random backwards compatibility stuff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,14 +121,8 @@ jobs:
           DJANGO_CORS_ALLOWED_ORIGINS: ${{ vars.DJANGO_CORS_ALLOWED_ORIGINS }}
           DJANGO_CSRF_TRUSTED_ORIGINS: ${{ vars.DJANGO_CSRF_TRUSTED_ORIGINS }}
           DJANGO_FORCE_SCRIPT_NAME: ${{ vars.DJANGO_FORCE_SCRIPT_NAME }}
-          # Preferred (unambiguous and short)
           CLOUDFLARE_ORIGIN_CERT_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_B64 }}
           CLOUDFLARE_ORIGIN_KEY_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_B64 }}
-          # Back-compat (deprecated): older secret names
-          CLOUDFLARE_ORIGIN_CERT_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM_B64 }}
-          CLOUDFLARE_ORIGIN_KEY_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM_B64 }}
-          CF_ORIGIN_CERT_B64: ${{ secrets.CF_ORIGIN_CERT_B64 }}
-          CF_ORIGIN_KEY_B64: ${{ secrets.CF_ORIGIN_KEY_B64 }}
         with:
           host: ${{ vars.DEPLOY_HOST }}
           username: ${{ vars.DEPLOY_USER }}


### PR DESCRIPTION
## 📌 Summary (what & why):
- Removes support for several deprecated Cloudflare TLS secret names from the deployment GitHub Actions workflow.
- Keeps only the current, preferred `CLOUDFLARE_ORIGIN_CERT_B64` and `CLOUDFLARE_ORIGIN_KEY_B64` secrets, simplifying configuration and reducing ambiguity around which secrets are actually used.

## 📂 Scope (what areas are affected):
- CI/CD:
  - GitHub Actions deployment workflow (`.github/workflows/deploy.yml`).
- Infrastructure / Ops:
  - Cloudflare origin certificate/key secret naming conventions in GitHub repository settings.

## 🔄 Behavior Changes (user-visible or API-visible):
- Deployments will no longer read from the legacy secret names:
  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64`
  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64`
  - `CF_ORIGIN_CERT_B64`
  - `CF_ORIGIN_KEY_B64`
- Operational requirement: the new canonical secrets (`CLOUDFLARE_ORIGIN_CERT_B64`, `CLOUDFLARE_ORIGIN_KEY_B64`) must be present and correctly configured; otherwise deployments will fail at runtime when trying to use TLS materials.