### PR TITLE
removed legacy fallbacks

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -44,7 +44,7 @@ What it does:
 Deployment prerequisite:
 - For Cloudflare Full (strict), the origin must have a Cloudflare Origin Certificate.
 - Option A (manual): provision on the server at `certs/origin.pem` and `certs/origin.key` (see `deploy/README.md`).
-- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_B64` and `CLOUDFLARE_ORIGIN_KEY_B64` so the workflow writes the files to `certs/` during deploy.
+- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` so the workflow writes the files to `certs/` during deploy.
 
 Deploy inputs (GitHub repo vars / secrets):
 - Server connection: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`, optional `DEPLOY_PORT`, secret `DEPLOY_SSH_KEY`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,14 +121,14 @@ jobs:
           DJANGO_CORS_ALLOWED_ORIGINS: ${{ vars.DJANGO_CORS_ALLOWED_ORIGINS }}
           DJANGO_CSRF_TRUSTED_ORIGINS: ${{ vars.DJANGO_CSRF_TRUSTED_ORIGINS }}
           DJANGO_FORCE_SCRIPT_NAME: ${{ vars.DJANGO_FORCE_SCRIPT_NAME }}
-          CLOUDFLARE_ORIGIN_CERT_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_B64 }}
-          CLOUDFLARE_ORIGIN_KEY_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_B64 }}
+          CLOUDFLARE_ORIGIN_CERT_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM_B64 }}
+          CLOUDFLARE_ORIGIN_KEY_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM_B64 }}
         with:
           host: ${{ vars.DEPLOY_HOST }}
           username: ${{ vars.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
-          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS,DJANGO_CSRF_TRUSTED_ORIGINS,DJANGO_FORCE_SCRIPT_NAME,CLOUDFLARE_ORIGIN_CERT_B64,CLOUDFLARE_ORIGIN_KEY_B64,CLOUDFLARE_ORIGIN_CERT_PEM_B64,CLOUDFLARE_ORIGIN_KEY_PEM_B64,CF_ORIGIN_CERT_B64,CF_ORIGIN_KEY_B64
+          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS,DJANGO_CSRF_TRUSTED_ORIGINS,DJANGO_FORCE_SCRIPT_NAME,CLOUDFLARE_ORIGIN_CERT_PEM_B64,CLOUDFLARE_ORIGIN_KEY_PEM_B64
           script: |
             set -e
             cd "${{ vars.DEPLOY_PATH }}"
@@ -139,33 +139,23 @@ jobs:
             # If provided, write the Cloudflare Origin cert/key from GitHub Secrets.
             # Otherwise, expect the files to already exist on the server.
             mkdir -p certs
-            # Prefer CLOUDFLARE_ORIGIN_{CERT,KEY}_B64; fall back to deprecated names if needed.
-            if [ -z "${CLOUDFLARE_ORIGIN_CERT_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM_B64:-}" ]; then
-              echo "Warning: using deprecated secret CLOUDFLARE_ORIGIN_CERT_PEM_B64; rename to CLOUDFLARE_ORIGIN_CERT_B64."
-              CLOUDFLARE_ORIGIN_CERT_B64="$CLOUDFLARE_ORIGIN_CERT_PEM_B64"
-            fi
-            if [ -z "${CLOUDFLARE_ORIGIN_KEY_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM_B64:-}" ]; then
-              echo "Warning: using deprecated secret CLOUDFLARE_ORIGIN_KEY_PEM_B64; rename to CLOUDFLARE_ORIGIN_KEY_B64."
-              CLOUDFLARE_ORIGIN_KEY_B64="$CLOUDFLARE_ORIGIN_KEY_PEM_B64"
-            fi
-            if [ -z "${CLOUDFLARE_ORIGIN_CERT_B64:-}" ] && [ -n "${CF_ORIGIN_CERT_B64:-}" ]; then
-              echo "Warning: using deprecated secret CF_ORIGIN_CERT_B64; rename to CLOUDFLARE_ORIGIN_CERT_B64."
-              CLOUDFLARE_ORIGIN_CERT_B64="$CF_ORIGIN_CERT_B64"
-            fi
-            if [ -z "${CLOUDFLARE_ORIGIN_KEY_B64:-}" ] && [ -n "${CF_ORIGIN_KEY_B64:-}" ]; then
-              echo "Warning: using deprecated secret CF_ORIGIN_KEY_B64; rename to CLOUDFLARE_ORIGIN_KEY_B64."
-              CLOUDFLARE_ORIGIN_KEY_B64="$CF_ORIGIN_KEY_B64"
-            fi
 
-            if [ -n "${CLOUDFLARE_ORIGIN_CERT_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_B64:-}" ]; then
+            if [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM_B64:-}" ]; then
               umask 077
-              echo "$CLOUDFLARE_ORIGIN_CERT_B64" | base64 -d > certs/origin.pem
-              echo "$CLOUDFLARE_ORIGIN_KEY_B64" | base64 -d > certs/origin.key
+              # Sanitize potential CR/LF from copied secrets before decoding.
+              if ! printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | tr -d '\r\n' | base64 -d > certs/origin.pem; then
+                echo "Failed to base64-decode CLOUDFLARE_ORIGIN_CERT_PEM_B64. Ensure the secret value is base64 (not raw PEM) and is copied without extra characters."
+                exit 1
+              fi
+              if ! printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | tr -d '\r\n' | base64 -d > certs/origin.key; then
+                echo "Failed to base64-decode CLOUDFLARE_ORIGIN_KEY_PEM_B64. Ensure the secret value is base64 (not raw PEM) and is copied without extra characters."
+                exit 1
+              fi
               chmod 644 certs/origin.pem
               chmod 600 certs/origin.key
             else
               if [ ! -f certs/origin.pem ] || [ ! -f certs/origin.key ]; then
-                echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_B64 and CLOUDFLARE_ORIGIN_KEY_B64."
+                echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_PEM_B64 and CLOUDFLARE_ORIGIN_KEY_PEM_B64."
                 exit 1
               fi
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,8 @@ Infra: Production runs behind Cloudflare (DNS/proxy) on a DigitalOcean VM. If yo
      - `/root/apps/notoli/certs/origin.pem`
      - `/root/apps/notoli/certs/origin.key`
    - Optional (automated deploy): store base64-encoded values in GitHub Secrets:
-     - `CLOUDFLARE_ORIGIN_CERT_B64` (base64 of `origin.pem`)
-     - `CLOUDFLARE_ORIGIN_KEY_B64` (base64 of `origin.key`)
+     - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (base64 of `origin.pem`)
+     - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (base64 of `origin.key`)
    - These are mounted into the proxy container as `/etc/nginx/certs` (see `deploy/docker-compose.yml`).
 3) Ensure the SQLite file exists when using the bind mount:
    - `cd deploy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Enabled full end-to-end HTTPS (Cloudflare -> origin) via Nginx TLS on port 443 using Cloudflare Origin Certificates; port 80 now redirects to HTTPS.
 - Updated Docker Compose/Nginx proxy config to publish `443` and mount origin certs into the proxy container.
-- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_B64`, `CLOUDFLARE_ORIGIN_KEY_B64`) and writes them to `certs/` on the server during deploy.
+- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_PEM_B64`, `CLOUDFLARE_ORIGIN_KEY_PEM_B64`) and writes them to `certs/` on the server during deploy.
 - Updated documentation for Cloudflare `Full (strict)` and certificate provisioning.
 
 ## 2026-02-06

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,8 +26,8 @@ Production (recommended): generate a Cloudflare Origin Certificate for `judeandr
 
 Optional: provision via GitHub Actions Secrets (recommended for repeatable deploys)
 - Create GitHub Secrets:
-  - `CLOUDFLARE_ORIGIN_CERT_B64` (base64-encoded `origin.pem`)
-  - `CLOUDFLARE_ORIGIN_KEY_B64` (base64-encoded `origin.key`)
+  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (base64-encoded `origin.pem`)
+  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (base64-encoded `origin.key`)
 
 Base64 helpers:
 - Linux/macOS: `base64 -w0 certs/origin.pem` and `base64 -w0 certs/origin.key`


### PR DESCRIPTION
## 📌 Summary (what & why):
- Renames the Cloudflare origin certificate/key GitHub Secrets to `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` to more clearly indicate they are base64-encoded PEM files.
- Simplifies the deploy workflow by dropping support for older/deprecated secret names and environment variables.
- Hardens the certificate handling in the deploy script by sanitizing line endings before base64 decoding and failing with clear error messages when decoding fails.
- Updates all related documentation (workflows README, deploy README, AGENTS guide, changelog) to reflect the new secret names and behavior.

## 📂 Scope (what areas are affected):
- GitHub Actions deploy workflow (`deploy.yml`), specifically:
  - Environment variables passed to the remote deploy step.
  - Logic that writes Cloudflare origin cert/key to `certs/origin.*` on the server.
- Deployment and infra documentation:
  - `.github/README-WORKFLOWS.md`
  - `deploy/README.md`
  - `AGENTS.md`
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- Deploys now expect only the new secret names:
  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64`
  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64`
  (Old names like `CLOUDFLARE_ORIGIN_CERT_B64`, `CLOUDFLARE_ORIGIN_KEY_B64`, `CF_ORIGIN_CERT_B64`, `CF_ORIGIN_KEY_B64` are no longer read or auto-mapped.)
- If the new secrets are set, the deploy script:
  - Strips any `\r`/`\n` characters from the secret values before base64-decoding.
  - Exits with a clear error message if decoding fails (e.g., if a raw PEM was pasted instead of base64).
- If the secrets are not provided and `certs/origin.pem` / `certs/origin.key` are missing on the server, the deploy now instructs users to set the new `_PEM_B64` secrets in the failure message.