### PR TITLE
raw PEM now accepted

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -44,7 +44,7 @@ What it does:
 Deployment prerequisite:
 - For Cloudflare Full (strict), the origin must have a Cloudflare Origin Certificate.
 - Option A (manual): provision on the server at `certs/origin.pem` and `certs/origin.key` (see `deploy/README.md`).
-- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` so the workflow writes the files to `certs/` during deploy.
+- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` so the workflow uploads the files to `certs/` during deploy (raw PEM accepted).
 
 Deploy inputs (GitHub repo vars / secrets):
 - Server connection: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`, optional `DEPLOY_PORT`, secret `DEPLOY_SSH_KEY`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,40 @@ jobs:
           fi
           echo "deploy_port=$DEPLOY_PORT" >> "$GITHUB_OUTPUT"
 
+      - name: Stage deploy bundle (including TLS certs)
+        shell: bash
+        env:
+          CLOUDFLARE_ORIGIN_CERT_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM_B64 }}
+          CLOUDFLARE_ORIGIN_KEY_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM_B64 }}
+        run: |
+          set -euo pipefail
+
+          rm -rf deploy_bundle
+          mkdir -p deploy_bundle/certs
+
+          cp deploy/docker-compose.yml deploy_bundle/docker-compose.yml
+          cp deploy/nginx-proxy.conf deploy_bundle/nginx-proxy.conf
+
+          # Write certs into the bundle if secrets exist.
+          # Raw PEM is preferred here because ssh-action env vars don't reliably support multi-line values.
+          if [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM_B64:-}" ]; then
+            if printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | grep -q "BEGIN CERTIFICATE"; then
+              printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" > deploy_bundle/certs/origin.pem
+            else
+              # Support base64 too, even though the secret name contains `_B64`.
+              printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | tr -d ' \t\r\n' | base64 -d -i > deploy_bundle/certs/origin.pem
+            fi
+
+            if printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | grep -q "BEGIN .*PRIVATE KEY"; then
+              printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" > deploy_bundle/certs/origin.key
+            else
+              printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | tr -d ' \t\r\n' | base64 -d -i > deploy_bundle/certs/origin.key
+            fi
+
+            chmod 644 deploy_bundle/certs/origin.pem
+            chmod 600 deploy_bundle/certs/origin.key
+          fi
+
       - name: Upload deploy files
         uses: appleboy/scp-action@v1
         with:
@@ -106,7 +140,7 @@ jobs:
           username: ${{ vars.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
-          source: "deploy/docker-compose.yml,deploy/nginx-proxy.conf"
+          source: "deploy_bundle/docker-compose.yml,deploy_bundle/nginx-proxy.conf,deploy_bundle/certs/origin.pem,deploy_bundle/certs/origin.key"
           target: ${{ vars.DEPLOY_PATH }}
           strip_components: 1
           overwrite: true
@@ -121,14 +155,12 @@ jobs:
           DJANGO_CORS_ALLOWED_ORIGINS: ${{ vars.DJANGO_CORS_ALLOWED_ORIGINS }}
           DJANGO_CSRF_TRUSTED_ORIGINS: ${{ vars.DJANGO_CSRF_TRUSTED_ORIGINS }}
           DJANGO_FORCE_SCRIPT_NAME: ${{ vars.DJANGO_FORCE_SCRIPT_NAME }}
-          CLOUDFLARE_ORIGIN_CERT_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM_B64 }}
-          CLOUDFLARE_ORIGIN_KEY_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM_B64 }}
         with:
           host: ${{ vars.DEPLOY_HOST }}
           username: ${{ vars.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
-          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS,DJANGO_CSRF_TRUSTED_ORIGINS,DJANGO_FORCE_SCRIPT_NAME,CLOUDFLARE_ORIGIN_CERT_PEM_B64,CLOUDFLARE_ORIGIN_KEY_PEM_B64
+          envs: DJANGO_DEBUG,DJANGO_SECRET_KEY,DJANGO_SQLITE_PATH,DJANGO_ALLOWED_HOSTS,DJANGO_CORS_ALLOWED_ORIGINS,DJANGO_CSRF_TRUSTED_ORIGINS,DJANGO_FORCE_SCRIPT_NAME
           script: |
             set -e
             cd "${{ vars.DEPLOY_PATH }}"
@@ -136,29 +168,13 @@ jobs:
             : "${DJANGO_SQLITE_PATH:=/backend/db.sqlite3}"
             : "${DJANGO_FORCE_SCRIPT_NAME:=/apps/notoli}"
 
-            # If provided, write the Cloudflare Origin cert/key from GitHub Secrets.
-            # Otherwise, expect the files to already exist on the server.
-            mkdir -p certs
-
-            if [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM_B64:-}" ]; then
-              umask 077
-              # Sanitize potential CR/LF from copied secrets before decoding.
-              if ! printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | tr -d '\r\n' | base64 -d > certs/origin.pem; then
-                echo "Failed to base64-decode CLOUDFLARE_ORIGIN_CERT_PEM_B64. Ensure the secret value is base64 (not raw PEM) and is copied without extra characters."
-                exit 1
-              fi
-              if ! printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | tr -d '\r\n' | base64 -d > certs/origin.key; then
-                echo "Failed to base64-decode CLOUDFLARE_ORIGIN_KEY_PEM_B64. Ensure the secret value is base64 (not raw PEM) and is copied without extra characters."
-                exit 1
-              fi
-              chmod 644 certs/origin.pem
-              chmod 600 certs/origin.key
-            else
-              if [ ! -f certs/origin.pem ] || [ ! -f certs/origin.key ]; then
-                echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_PEM_B64 and CLOUDFLARE_ORIGIN_KEY_PEM_B64."
-                exit 1
-              fi
+            # TLS certs are uploaded as files (via SCP) to avoid multi-line env var issues.
+            if [ ! -f certs/origin.pem ] || [ ! -f certs/origin.key ]; then
+              echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_PEM_B64 and CLOUDFLARE_ORIGIN_KEY_PEM_B64 (raw PEM is accepted)."
+              exit 1
             fi
+            chmod 644 certs/origin.pem
+            chmod 600 certs/origin.key
 
             cat > .env <<EOF
             DJANGO_DEBUG=$DJANGO_DEBUG

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,9 @@ Infra: Production runs behind Cloudflare (DNS/proxy) on a DigitalOcean VM. If yo
    - Production (Cloudflare Origin Certificate):
      - `/root/apps/notoli/certs/origin.pem`
      - `/root/apps/notoli/certs/origin.key`
-   - Optional (automated deploy): store base64-encoded values in GitHub Secrets:
-     - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (base64 of `origin.pem`)
-     - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (base64 of `origin.key`)
+   - Optional (automated deploy): store values in GitHub Secrets (raw PEM or base64):
+     - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (raw PEM or base64 of `origin.pem`)
+     - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (raw PEM or base64 of `origin.key`)
    - These are mounted into the proxy container as `/etc/nginx/certs` (see `deploy/docker-compose.yml`).
 3) Ensure the SQLite file exists when using the bind mount:
    - `cd deploy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Enabled full end-to-end HTTPS (Cloudflare -> origin) via Nginx TLS on port 443 using Cloudflare Origin Certificates; port 80 now redirects to HTTPS.
 - Updated Docker Compose/Nginx proxy config to publish `443` and mount origin certs into the proxy container.
-- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_PEM_B64`, `CLOUDFLARE_ORIGIN_KEY_PEM_B64`) and writes them to `certs/` on the server during deploy.
+- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_PEM_B64`, `CLOUDFLARE_ORIGIN_KEY_PEM_B64`) and uploads them to `certs/` on the server during deploy (raw PEM accepted).
 - Updated documentation for Cloudflare `Full (strict)` and certificate provisioning.
 
 ## 2026-02-06

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,8 +26,8 @@ Production (recommended): generate a Cloudflare Origin Certificate for `judeandr
 
 Optional: provision via GitHub Actions Secrets (recommended for repeatable deploys)
 - Create GitHub Secrets:
-  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (base64-encoded `origin.pem`)
-  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (base64-encoded `origin.key`)
+  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (raw PEM or base64-encoded `origin.pem`)
+  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (raw PEM or base64-encoded `origin.key`)
 
 Base64 helpers:
 - Linux/macOS: `base64 -w0 certs/origin.pem` and `base64 -w0 certs/origin.key`


### PR DESCRIPTION
## 📌 Summary (what & why):
- Adjusts the deploy GitHub Action so TLS certificates are staged and uploaded as files via SCP instead of being passed as multi-line environment variables over SSH.
- Adds support for storing Cloudflare origin cert/key secrets as either raw PEM or base64, making configuration less fragile and easier to set up.
- Updates documentation (workflows README, deploy README, AGENTS, CHANGELOG) to reflect the new behavior and clarify that raw PEM is accepted.

## 📂 Scope (what areas are affected):
- GitHub Actions deploy workflow (`deploy.yml`), specifically:
  - How `docker-compose.yml`, `nginx-proxy.conf`, and TLS certs are bundled and transferred.
  - How TLS certs are validated and permissions set on the server.
- Deployment / infra documentation:
  - `.github/README-WORKFLOWS.md`
  - `deploy/README.md`
  - `AGENTS.md`
  - `CHANGELOG.md`

## 🔄 Behavior Changes (user-visible or API-visible):
- Deploys now:
  - Build a `deploy_bundle/` directory locally, including `certs/origin.pem` and `certs/origin.key` when secrets are present.
  - Upload these files directly via SCP, instead of reconstructing them from base64 inside the remote SSH session.
- TLS secret handling:
  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` may now be either raw PEM or base64; the workflow auto-detects and decodes as needed.
  - These secrets are no longer passed as SSH environment variables, reducing issues with multi-line values and improving reliability.
- On the server, the deploy script now:
  - Expects `certs/origin.pem` and `certs/origin.key` to already exist (either manually provisioned or uploaded by the workflow).
  - Enforces correct file permissions on the cert and key before continuing.