### PR TITLE
PEM only

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -44,7 +44,7 @@ What it does:
 Deployment prerequisite:
 - For Cloudflare Full (strict), the origin must have a Cloudflare Origin Certificate.
 - Option A (manual): provision on the server at `certs/origin.pem` and `certs/origin.key` (see `deploy/README.md`).
-- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_PEM_B64` and `CLOUDFLARE_ORIGIN_KEY_PEM_B64` so the workflow uploads the files to `certs/` during deploy (raw PEM accepted).
+- Option B (automated): set GitHub Secrets `CLOUDFLARE_ORIGIN_CERT_PEM` and `CLOUDFLARE_ORIGIN_KEY_PEM` so the workflow uploads the files to `certs/` during deploy.
 
 Deploy inputs (GitHub repo vars / secrets):
 - Server connection: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`, optional `DEPLOY_PORT`, secret `DEPLOY_SSH_KEY`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,10 +100,11 @@ jobs:
           echo "deploy_port=$DEPLOY_PORT" >> "$GITHUB_OUTPUT"
 
       - name: Stage deploy bundle (including TLS certs)
+        id: stage_bundle
         shell: bash
         env:
-          CLOUDFLARE_ORIGIN_CERT_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM_B64 }}
-          CLOUDFLARE_ORIGIN_KEY_PEM_B64: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM_B64 }}
+          CLOUDFLARE_ORIGIN_CERT_PEM: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_PEM }}
+          CLOUDFLARE_ORIGIN_KEY_PEM: ${{ secrets.CLOUDFLARE_ORIGIN_KEY_PEM }}
         run: |
           set -euo pipefail
 
@@ -115,22 +116,24 @@ jobs:
 
           # Write certs into the bundle if secrets exist.
           # Raw PEM is preferred here because ssh-action env vars don't reliably support multi-line values.
-          if [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM_B64:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM_B64:-}" ]; then
-            if printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | grep -q "BEGIN CERTIFICATE"; then
-              printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" > deploy_bundle/certs/origin.pem
-            else
-              # Support base64 too, even though the secret name contains `_B64`.
-              printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM_B64" | tr -d ' \t\r\n' | base64 -d -i > deploy_bundle/certs/origin.pem
+          if [ -n "${CLOUDFLARE_ORIGIN_CERT_PEM:-}" ] && [ -n "${CLOUDFLARE_ORIGIN_KEY_PEM:-}" ]; then
+            if ! printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM" | grep -q "BEGIN CERTIFICATE"; then
+              echo "CLOUDFLARE_ORIGIN_CERT_PEM is set but does not look like PEM (missing BEGIN CERTIFICATE)."
+              exit 1
+            fi
+            if ! printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM" | grep -q "BEGIN .*PRIVATE KEY"; then
+              echo "CLOUDFLARE_ORIGIN_KEY_PEM is set but does not look like PEM (missing BEGIN PRIVATE KEY)."
+              exit 1
             fi
 
-            if printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | grep -q "BEGIN .*PRIVATE KEY"; then
-              printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" > deploy_bundle/certs/origin.key
-            else
-              printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM_B64" | tr -d ' \t\r\n' | base64 -d -i > deploy_bundle/certs/origin.key
-            fi
-
+            printf '%s' "$CLOUDFLARE_ORIGIN_CERT_PEM" > deploy_bundle/certs/origin.pem
+            printf '%s' "$CLOUDFLARE_ORIGIN_KEY_PEM" > deploy_bundle/certs/origin.key
             chmod 644 deploy_bundle/certs/origin.pem
             chmod 600 deploy_bundle/certs/origin.key
+
+            echo "certs_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "certs_present=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload deploy files
@@ -140,9 +143,22 @@ jobs:
           username: ${{ vars.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ steps.deploy_vars.outputs.deploy_port }}
-          source: "deploy_bundle/docker-compose.yml,deploy_bundle/nginx-proxy.conf,deploy_bundle/certs/origin.pem,deploy_bundle/certs/origin.key"
+          source: "deploy_bundle/docker-compose.yml,deploy_bundle/nginx-proxy.conf"
           target: ${{ vars.DEPLOY_PATH }}
           strip_components: 1
+          overwrite: true
+
+      - name: Upload TLS certs
+        if: ${{ steps.stage_bundle.outputs.certs_present == 'true' }}
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ vars.DEPLOY_HOST }}
+          username: ${{ vars.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ steps.deploy_vars.outputs.deploy_port }}
+          source: "deploy_bundle/certs/origin.pem,deploy_bundle/certs/origin.key"
+          target: ${{ vars.DEPLOY_PATH }}/certs
+          strip_components: 2
           overwrite: true
 
       - name: Deploy via SSH
@@ -170,7 +186,7 @@ jobs:
 
             # TLS certs are uploaded as files (via SCP) to avoid multi-line env var issues.
             if [ ! -f certs/origin.pem ] || [ ! -f certs/origin.key ]; then
-              echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_PEM_B64 and CLOUDFLARE_ORIGIN_KEY_PEM_B64 (raw PEM is accepted)."
+              echo "Missing TLS certs. Either provision certs/origin.pem + certs/origin.key on the server, or set GitHub Secrets CLOUDFLARE_ORIGIN_CERT_PEM and CLOUDFLARE_ORIGIN_KEY_PEM."
               exit 1
             fi
             chmod 644 certs/origin.pem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,9 @@ Infra: Production runs behind Cloudflare (DNS/proxy) on a DigitalOcean VM. If yo
    - Production (Cloudflare Origin Certificate):
      - `/root/apps/notoli/certs/origin.pem`
      - `/root/apps/notoli/certs/origin.key`
-   - Optional (automated deploy): store values in GitHub Secrets (raw PEM or base64):
-     - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (raw PEM or base64 of `origin.pem`)
-     - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (raw PEM or base64 of `origin.key`)
+   - Optional (automated deploy): store raw PEM values in GitHub Secrets:
+     - `CLOUDFLARE_ORIGIN_CERT_PEM` (raw PEM of `origin.pem`)
+     - `CLOUDFLARE_ORIGIN_KEY_PEM` (raw PEM of `origin.key`)
    - These are mounted into the proxy container as `/etc/nginx/certs` (see `deploy/docker-compose.yml`).
 3) Ensure the SQLite file exists when using the bind mount:
    - `cd deploy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - Enabled full end-to-end HTTPS (Cloudflare -> origin) via Nginx TLS on port 443 using Cloudflare Origin Certificates; port 80 now redirects to HTTPS.
 - Updated Docker Compose/Nginx proxy config to publish `443` and mount origin certs into the proxy container.
-- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_PEM_B64`, `CLOUDFLARE_ORIGIN_KEY_PEM_B64`) and uploads them to `certs/` on the server during deploy (raw PEM accepted).
+- Deploy workflow can now provision origin cert/key from GitHub Secrets (`CLOUDFLARE_ORIGIN_CERT_PEM`, `CLOUDFLARE_ORIGIN_KEY_PEM`) and uploads them to `certs/` on the server during deploy.
 - Updated documentation for Cloudflare `Full (strict)` and certificate provisioning.
 
 ## 2026-02-06

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,14 +26,8 @@ Production (recommended): generate a Cloudflare Origin Certificate for `judeandr
 
 Optional: provision via GitHub Actions Secrets (recommended for repeatable deploys)
 - Create GitHub Secrets:
-  - `CLOUDFLARE_ORIGIN_CERT_PEM_B64` (raw PEM or base64-encoded `origin.pem`)
-  - `CLOUDFLARE_ORIGIN_KEY_PEM_B64` (raw PEM or base64-encoded `origin.key`)
-
-Base64 helpers:
-- Linux/macOS: `base64 -w0 certs/origin.pem` and `base64 -w0 certs/origin.key`
-- Windows PowerShell:
-  - ` [Convert]::ToBase64String([IO.File]::ReadAllBytes('certs\\origin.pem')) `
-  - ` [Convert]::ToBase64String([IO.File]::ReadAllBytes('certs\\origin.key')) `
+  - `CLOUDFLARE_ORIGIN_CERT_PEM` (raw PEM of `origin.pem`)
+  - `CLOUDFLARE_ORIGIN_KEY_PEM` (raw PEM of `origin.key`)
 
 Local dev (optional): you can generate a self-signed cert for `localhost` and place it in `certs/`.
 


### PR DESCRIPTION
## 📌 Summary (what & why):
- Simplifies how Cloudflare origin TLS certificates are provided to the deploy workflow by switching from flexible “maybe-base64” secrets to strictly raw PEM secrets.
- Adds validation that the provided cert and key actually look like PEM content before deploying, failing fast on misconfiguration.
- Adjusts the deployment process so TLS certs are uploaded separately from the main deploy bundle, reducing reliance on multi-line env handling quirks.
- Updates all related documentation and changelog entries to reflect the new secret names and expectations.

## 📂 Scope (what areas are affected):
- GitHub Actions deploy workflow (`deploy.yml`), especially TLS certificate handling and file upload steps.
- Deployment and infra documentation (`.github/README-WORKFLOWS.md`, `deploy/README.md`, `AGENTS.md`).
- Project changelog entry describing HTTPS / Cloudflare origin certificate support.

## 🔄 Behavior Changes (user-visible or API-visible):
- Deploys now expect GitHub Secrets named `CLOUDFLARE_ORIGIN_CERT_PEM` and `CLOUDFLARE_ORIGIN_KEY_PEM` containing raw PEM (no base64); the old `_B64` secrets are no longer used.
- If those secrets are set but do not contain valid-looking PEM (missing `BEGIN CERTIFICATE` / `BEGIN …PRIVATE KEY`), the deploy job will fail with a clear error instead of trying to guess/auto-decode.
- TLS certs are uploaded via a dedicated SCP step into `<DEPLOY_PATH>/certs`, only when present, rather than always being bundled and uploaded with the rest of the deploy files.
- Error messaging on the server side now references the new secret names when TLS certs are missing.