### PR TITLE
Authentication 01

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Infra: Production runs behind Cloudflare (DNS/proxy) on a DigitalOcean VM. If yo
   - `REACT_APP_API_BASE_URL=https://judeandrewalaba.com/apps/notoli`
 - Frontend auth behavior:
   - Tokens live in `sessionStorage` (`accessToken`/`refreshToken`).
-  - Any backend `401` from non-login/register endpoints clears tokens and redirects to `/login` (under the `PUBLIC_URL` basename, e.g. `/apps/notoli/login`).
+  - Any backend `401` from non-login/register endpoints clears tokens and redirects to `/login` (under the `PUBLIC_URL` basename, e.g. `/apps/notoli/login`) and shows an error snackbar on the login page.
 
 ## Maintenance
 - Backend migrations: `python backend/manage.py makemigrations` then `python backend/manage.py migrate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Note PATCH `todo_list` attach now enforces todo list access (prevents injecting notes into lists you can't access).
 - `?workspace=` list filters now work for users who have item-level access (note/todolist collaborators) even if they are not workspace collaborators.
 - Frontend now clears auth tokens and redirects to `/login` when an API request returns `401 Unauthorized` (instead of showing a raw `HTTP 401` error).
+- Frontend now shows an error snackbar on `/login` after a `401` redirect so users understand why they were logged out.
 ### Changed
 - Improved Django admin list views for Workspaces, Todo Lists, and Notes to show owner/collaborators (and workspace for todo lists).
 - Notes now belong to a Workspace (tenancy boundary), and Todo Lists can only include Notes from the same Workspace.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,7 +11,7 @@ The Notoli frontend is a Create React App (CRA) single-page app with React Route
 
 Authentication tokens are stored in `sessionStorage` (`accessToken` and `refreshToken`).
 The refresh token is stored for later use, but the frontend currently does not auto-refresh access tokens.
-If an API request returns `401 Unauthorized` (expired/invalid token), the frontend clears stored tokens and redirects to `/login`.
+If an API request returns `401 Unauthorized` (expired/invalid token), the frontend clears stored tokens, redirects to `/login`, and shows an error snackbar explaining the logout.
 
 ## 🧩 Path-Based Hosting (`/apps/notoli`)
 

--- a/frontend/src/pages/authentication/Login.js
+++ b/frontend/src/pages/authentication/Login.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { TextField, Button, Typography, Box, Paper, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { fetchWorkspaces as fetchWorkspacesApi, login } from '../../services/backendClient';
@@ -9,6 +9,24 @@ export default function Login({ showSnackbar }) {
   const [password, setPassword] = useState('');
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem('pendingSnackbar');
+    if (!raw) return;
+
+    sessionStorage.removeItem('pendingSnackbar');
+
+    if (typeof showSnackbar !== 'function') return;
+
+    try {
+      const payload = JSON.parse(raw);
+      const severity = payload?.severity || 'error';
+      const message = payload?.message || 'Please log in again.';
+      showSnackbar(severity, message);
+    } catch (_err) {
+      showSnackbar('error', 'Please log in again.');
+    }
+  }, [showSnackbar]);
 
   // Pull Workspace List
   const fetchWorkspaces = useCallback(

--- a/frontend/src/pages/authentication/Login.test.js
+++ b/frontend/src/pages/authentication/Login.test.js
@@ -42,6 +42,26 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
   });
 
+  test('when a pending snackbar exists in sessionStorage, it shows it once on render', async () => {
+    sessionStorage.setItem(
+      'pendingSnackbar',
+      JSON.stringify({ severity: 'error', message: 'Your session expired. Please log in again.' }),
+    );
+
+    const showSnackbar = jest.fn();
+
+    renderWithProviders(<Login showSnackbar={showSnackbar} />);
+
+    await waitFor(() => {
+      expect(showSnackbar).toHaveBeenCalledWith(
+        'error',
+        'Your session expired. Please log in again.',
+      );
+    });
+
+    expect(sessionStorage.getItem('pendingSnackbar')).toBeNull();
+  });
+
   test('when login succeeds and workspaces exist, it navigates to the first workspace', async () => {
     fetchWorkspaces.mockResolvedValueOnce({
       ok: true,

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -37,6 +37,19 @@ function handleUnauthorized() {
   const normalizedRegister = registerPath.replace(/\/+$/, '');
   if (currentPath === normalizedLogin || currentPath === normalizedRegister) return;
 
+  // Let the login screen explain why the user got redirected.
+  try {
+    sessionStorage.setItem(
+      'pendingSnackbar',
+      JSON.stringify({
+        severity: 'error',
+        message: 'Your session expired. Please log in again.',
+      }),
+    );
+  } catch (_err) {
+    // ignore
+  }
+
   const isJsdom =
     typeof navigator !== 'undefined' &&
     typeof navigator.userAgent === 'string' &&

--- a/frontend/src/services/apiClient.test.js
+++ b/frontend/src/services/apiClient.test.js
@@ -61,6 +61,10 @@ describe('apiClient', () => {
 
     expect(sessionStorage.getItem('accessToken')).toBeNull();
     expect(sessionStorage.getItem('refreshToken')).toBeNull();
+    expect(JSON.parse(sessionStorage.getItem('pendingSnackbar'))).toEqual({
+      severity: 'error',
+      message: 'Your session expired. Please log in again.',
+    });
     expect(window.location.pathname).toBe('/apps/notoli/login');
   });
 


### PR DESCRIPTION
## 📌 Summary (what & why):

- Documents and implements a consistent frontend auth failure flow: when the backend returns `401 Unauthorized` for non-auth endpoints, the app now logs the user out, redirects them to the login page, and explains what happened.
- Persists a “pending snackbar” message in `sessionStorage` so that, after a forced redirect, the login page can show a clear error about session expiry.
- Clarifies this behavior in project docs (`AGENTS.md`, frontend `README.md`, `CHANGELOG.md`) so operators and contributors understand how auth and redirects work.
- Adds tests around the new 401-handling logic and the login page’s snackbar behavior; also includes a minor test formatting cleanup on the backend.

## 📂 Scope (what areas are affected):

- Frontend:
  - Global API client (`frontend/src/services/apiClient.js` and tests).
  - Authentication UI, specifically the Login page and its tests.
  - Frontend documentation about auth and hosting behavior.
- Backend:
  - Test file for notes/todo lists (only stylistic change to a test name).
- Project-wide docs:
  - Agent/operator guidance and changelog entries.

## 🔄 Behavior Changes (user-visible or API-visible):

- For users:
  - If an authenticated API call (non-login/register) returns `401` (e.g., expired/invalid token), the app:
    - Clears stored `accessToken` and `refreshToken` from `sessionStorage`.
    - Redirects the user to `/login` under the configured `PUBLIC_URL` (e.g., `/apps/notoli/login`).
    - Shows an error snackbar on the login page explaining that the session expired and they need to log in again.
  - If the `401` comes from `/auth/login` or `/auth/register`, the app does not auto-logout or redirect; those are handled by the auth UI as before.
- For tests / environments:
  - In jsdom (test environment), redirects are simulated via `window.history.replaceState` rather than a full `window.location.replace`, avoiding issues with navigation in tests.
- No backend API contract changes; only frontend handling of existing `401` responses is updated.