### PR TITLE
issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 ## 2026-06-29
 ### Added
 - Added a Resend HTTPS API email backend for password-reset delivery on hosts where outbound SMTP is blocked.
+### Fixed
+- Added JSON accept and application user-agent headers to Resend API email requests so production requests are not rejected by Resend's Cloudflare layer.
+- Preserved CC and BCC fields separately when building Resend API email payloads.
 ### Changed
 - Expanded local Docker setup documentation with local TLS cert generation, SQLite bind-mount repair, local image rebuild steps, migration commands, URL checks, and the `DJANGO_EMAIL_HOST_KEY` env var note.
 - Added a default email timeout and deploy/env documentation for `DJANGO_EMAIL_TIMEOUT`.

--- a/backend/authentication/email_backends.py
+++ b/backend/authentication/email_backends.py
@@ -8,6 +8,7 @@ from django.core.mail.message import EmailMultiAlternatives
 
 class ResendApiEmailBackend(BaseEmailBackend):
     api_url = "https://api.resend.com/emails"
+    user_agent = "Notoli/1.0 (+https://judeandrewalaba.com/apps/notoli)"
 
     def send_messages(self, email_messages):
         if not email_messages:
@@ -33,10 +34,14 @@ class ResendApiEmailBackend(BaseEmailBackend):
     def _send_message(self, message, api_key):
         payload = {
             "from": message.from_email or settings.DEFAULT_FROM_EMAIL,
-            "to": message.recipients(),
+            "to": message.to,
             "subject": message.subject,
             "text": message.body,
         }
+        if message.cc:
+            payload["cc"] = message.cc
+        if message.bcc:
+            payload["bcc"] = message.bcc
 
         html_body = self._get_html_body(message)
         if html_body:
@@ -47,7 +52,9 @@ class ResendApiEmailBackend(BaseEmailBackend):
             data=json.dumps(payload).encode("utf-8"),
             headers={
                 "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
                 "Content-Type": "application/json",
+                "User-Agent": self.user_agent,
             },
             method="POST",
         )

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -664,6 +664,11 @@ class ResendApiEmailBackendTests(APITestCase):
             request_arg.get_header("Authorization"),
             "Bearer resend-api-key",
         )
+        self.assertEqual(request_arg.get_header("Accept"), "application/json")
+        self.assertEqual(
+            request_arg.get_header("User-agent"),
+            "Notoli/1.0 (+https://judeandrewalaba.com/apps/notoli)",
+        )
         self.assertEqual(mock_urlopen.call_args.kwargs.get("timeout"), 7)
 
         payload = json.loads(request_arg.data.decode("utf-8"))
@@ -671,6 +676,36 @@ class ResendApiEmailBackendTests(APITestCase):
         self.assertEqual(payload["to"], ["reset_user@example.com"])
         self.assertEqual(payload["subject"], "Reset your Notoli password")
         self.assertEqual(payload["text"], "Use this link.")
+
+    @override_settings(
+        EMAIL_BACKEND="authentication.email_backends.ResendApiEmailBackend",
+        EMAIL_HOST_PASSWORD="resend-api-key",
+        DEFAULT_FROM_EMAIL="notoli@example.com",
+    )
+    @patch("authentication.email_backends.request.urlopen")
+    def test_send_messages_preserves_cc_and_bcc(self, mock_urlopen):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.getcode.return_value = 200
+        mock_urlopen.return_value = response
+
+        message = EmailMessage(
+            "Subject",
+            "Body",
+            None,
+            ["to@example.com"],
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+        )
+
+        connection = get_connection()
+        connection.send_messages([message])
+
+        request_arg = mock_urlopen.call_args.args[0]
+        payload = json.loads(request_arg.data.decode("utf-8"))
+        self.assertEqual(payload["to"], ["to@example.com"])
+        self.assertEqual(payload["cc"], ["cc@example.com"])
+        self.assertEqual(payload["bcc"], ["bcc@example.com"])
 
     @override_settings(
         EMAIL_BACKEND="authentication.email_backends.ResendApiEmailBackend",


### PR DESCRIPTION
## 📌 Summary (what & why):
- Tightened the Resend HTTPS email backend so production password-reset emails are accepted by Resend’s infrastructure instead of being blocked by Cloudflare.
- Ensured CC and BCC recipients are correctly represented in Resend API payloads, preserving full email metadata.
- Documented these changes in the changelog, including clarifications around email configuration and timeouts.

## 📂 Scope (what areas are affected):
- Backend authentication email delivery via the `ResendApiEmailBackend`.
- Outbound password-reset and other transactional emails that use this backend.
- Project documentation / changelog related to email configuration and Docker/local setup.

## 🔄 Behavior Changes (user-visible or API-visible):
- Password reset and other emails sent through Resend now:
  - Include explicit `Accept: application/json` and a Notoli-specific `User-Agent` header, reducing the chance of being rejected by Resend’s Cloudflare layer.
  - Preserve `cc` and `bcc` fields separately instead of collapsing everything into `to`, so downstream email clients and logs show recipients correctly.
- No UI changes; impact is reliability and correctness of outbound email delivery and recipient handling.