### PR TITLE
Fix shared workspace child item access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-06-30
+### Fixed
+- Made shared workspace membership sufficient to retrieve newly created child todo lists and notes while preserving item-level collaborator access as additive sharing.
+
 ## 2026-06-29
 ### Changed
 - Renamed the Django project package from `backend/backend` to `backend/app` and updated settings, WSGI/ASGI, Docker, and documentation references.

--- a/backend/notes/serializers.py
+++ b/backend/notes/serializers.py
@@ -85,6 +85,9 @@ class NoteSerializer(serializers.ModelSerializer):
                     todo_list.owner_id == user.id
                     or todo_list.created_by_id == user.id
                     or todo_list.collaborators.filter(id=user.id).exists()
+                    or todo_list.workspace.owner_id == user.id
+                    or todo_list.workspace.created_by_id == user.id
+                    or todo_list.workspace.collaborators.filter(id=user.id).exists()
                 )
                 if not has_todolist_access:
                     raise PermissionDenied("You cannot add notes to this todo-list.")

--- a/backend/notes/tests.py
+++ b/backend/notes/tests.py
@@ -521,6 +521,68 @@ class TodoListApiTests(APITestCase):
             "TodoList workspace unexpectedly changed.",
         )
 
+    def test_workspace_collaborator_can_retrieve_owner_created_todolist_without_item_share(
+        self,
+    ):
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.get(f"/api/todolists/{self.todo_list.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected workspace collaborator to retrieve owner-created list, got {response.status_code}: {response.data}",
+        )
+        self.assertEqual(response.data.get("id"), self.todo_list.id)
+
+    def test_owner_can_retrieve_collaborator_created_todolist_without_item_share(self):
+        collaborator_list = TodoList.objects.create(
+            name="Collaborator Created List",
+            description="Shared through workspace",
+            workspace=self.workspace,
+            owner=self.collaborator,
+            created_by=self.collaborator,
+        )
+
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/todolists/{collaborator_list.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected workspace owner to retrieve collaborator-created list, got {response.status_code}: {response.data}",
+        )
+        self.assertEqual(response.data.get("id"), collaborator_list.id)
+
+    def test_workspace_membership_does_not_leak_todolists_from_other_workspaces(self):
+        other_member = User.objects.create_user(
+            username="other_member",
+            email="other_member@example.com",
+            password="other-member-password",
+        )
+        other_workspace = Workspace.objects.create(
+            name="Other Shared Workspace",
+            description="Separate sharing boundary",
+            owner=self.outsider,
+            created_by=self.outsider,
+        )
+        other_workspace.collaborators.add(other_member)
+        other_list = TodoList.objects.create(
+            name="Other Workspace List",
+            description="Should not leak",
+            workspace=other_workspace,
+            owner=self.outsider,
+            created_by=self.outsider,
+        )
+
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.get(f"/api/todolists/{other_list.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_404_NOT_FOUND,
+            f"Expected no access to another workspace's list, got {response.status_code}: {response.data}",
+        )
+
 
 class NoteApiTests(APITestCase):
     def setUp(self):
@@ -550,6 +612,7 @@ class NoteApiTests(APITestCase):
             owner=self.owner,
             created_by=self.owner,
         )
+        self.workspace.collaborators.add(self.collaborator)
         self.todo_list = TodoList.objects.create(
             name="Owner List",
             description="Owned List Description",
@@ -567,6 +630,95 @@ class NoteApiTests(APITestCase):
         )
         self.todo_list.notes.add(self.note)
         self.note.collaborators.add(self.note_only_collaborator)
+
+    def test_workspace_collaborator_can_retrieve_owner_created_note_without_item_share(
+        self,
+    ):
+        self.note.collaborators.clear()
+
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.get(f"/api/notes/{self.note.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected workspace collaborator to retrieve owner-created note, got {response.status_code}: {response.data}",
+        )
+        self.assertEqual(response.data.get("id"), self.note.id)
+
+    def test_owner_can_retrieve_collaborator_created_note_in_todolist_without_item_share(
+        self,
+    ):
+        collaborator_note = Note.objects.create(
+            note="Collaborator Created Note",
+            description="Shared through workspace list",
+            workspace=self.workspace,
+            owner=self.collaborator,
+            created_by=self.collaborator,
+        )
+        self.todo_list.notes.add(collaborator_note)
+
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/notes/{collaborator_note.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected workspace owner to retrieve collaborator-created note, got {response.status_code}: {response.data}",
+        )
+        self.assertEqual(response.data.get("id"), collaborator_note.id)
+
+    def test_collaborator_can_create_note_directly_in_shared_workspace(self):
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.post(
+            "/api/notes/",
+            {
+                "note": "Workspace Scoped Note",
+                "description": "Created directly in shared workspace",
+                "workspace": self.workspace.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED,
+            f"Expected collaborator to create workspace-scoped note, got {response.status_code}: {response.data}",
+        )
+        note = Note.objects.get(id=response.data.get("id"))
+        self.assertEqual(note.workspace_id, self.workspace.id)
+
+        self.client.force_authenticate(user=self.owner)
+        retrieve_response = self.client.get(f"/api/notes/{note.id}/")
+        self.assertEqual(
+            retrieve_response.status_code,
+            status.HTTP_200_OK,
+            f"Expected owner to retrieve collaborator-created workspace note, got {retrieve_response.status_code}: {retrieve_response.data}",
+        )
+
+    def test_workspace_membership_does_not_leak_notes_from_other_workspaces(self):
+        other_workspace = Workspace.objects.create(
+            name="Other Shared Workspace",
+            description="Separate sharing boundary",
+            owner=self.outsider,
+            created_by=self.outsider,
+        )
+        other_note = Note.objects.create(
+            note="Other Workspace Note",
+            description="Should not leak",
+            workspace=other_workspace,
+            owner=self.outsider,
+            created_by=self.outsider,
+        )
+
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.get(f"/api/notes/{other_note.id}/")
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_404_NOT_FOUND,
+            f"Expected no access to another workspace's note, got {response.status_code}: {response.data}",
+        )
 
     def test_create_note_as_collaborator(self):
         self.client.force_authenticate(user=self.collaborator)

--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -66,9 +66,16 @@ class TodoListViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
 
-        # Base queryset. Lists what the user owner/creator/collaborators on
+        # Workspace membership is sufficient to see child lists; item-level
+        # ownership/collaborators remain additive for lists shared outside the
+        # workspace.
         queryset = TodoList.objects.filter(
-            Q(owner=user) | Q(created_by=user) | Q(collaborators=user)
+            Q(owner=user)
+            | Q(created_by=user)
+            | Q(collaborators=user)
+            | Q(workspace__owner=user)
+            | Q(workspace__created_by=user)
+            | Q(workspace__collaborators=user)
         )
 
         # Adding additional querying capabilities by ?workspace=ID
@@ -85,9 +92,10 @@ class TodoListViewSet(viewsets.ModelViewSet):
         workspace = get_object_or_404(Workspace, pk=workspace_id)
 
         # Ensure user access to specified workspace
-        if not (
-            workspace.owner == self.request.user
-            or self.request.user in workspace.collaborators.all()
+        if (
+            not Workspace.objects.accessible_to(self.request.user)
+            .filter(pk=workspace.pk)
+            .exists()
         ):
             raise PermissionDenied("You cannot add todo-lists to this workspace.")
 
@@ -105,7 +113,12 @@ class NoteViewSet(viewsets.ModelViewSet):
         user = self.request.user
 
         queryset = Note.objects.filter(
-            Q(owner=user) | Q(created_by=user) | Q(collaborators=user)
+            Q(owner=user)
+            | Q(created_by=user)
+            | Q(collaborators=user)
+            | Q(workspace__owner=user)
+            | Q(workspace__created_by=user)
+            | Q(workspace__collaborators=user)
         )
 
         # Adding additional querying capabilities by ?workspace=ID
@@ -127,17 +140,25 @@ class NoteViewSet(viewsets.ModelViewSet):
 
         # Ensure user access to specified todo-list (when provided).
         if todo_list is not None:
-            if not (
-                todo_list.owner == self.request.user
-                or self.request.user in todo_list.collaborators.all()
-            ):
+            if not TodoList.objects.filter(
+                Q(pk=todo_list.pk)
+                & (
+                    Q(owner=self.request.user)
+                    | Q(created_by=self.request.user)
+                    | Q(collaborators=self.request.user)
+                    | Q(workspace__owner=self.request.user)
+                    | Q(workspace__created_by=self.request.user)
+                    | Q(workspace__collaborators=self.request.user)
+                )
+            ).exists():
                 raise PermissionDenied("You cannot add notes to this todo-list.")
 
         # Ensure user access to specified workspace (when creating a workspace-scoped note).
         if todo_list is None and workspace is not None:
-            if not (
-                workspace.owner == self.request.user
-                or self.request.user in workspace.collaborators.all()
+            if (
+                not Workspace.objects.accessible_to(self.request.user)
+                .filter(pk=workspace.pk)
+                .exists()
             ):
                 raise PermissionDenied("You cannot add notes to this workspace.")
 


### PR DESCRIPTION
### Motivation
- Ensure that todo lists and notes created inside a shared workspace are automatically visible to the workspace owner and collaborators rather than requiring per-item sharing. 
- Existing filtering and create-time checks only considered item-level ownership/collaborators which prevented workspace members from reliably seeing newly created child items.

### Description
- Broadened list/query access so `TodoList` and `Note` querysets include workspace membership by adding `Q(workspace__owner=...)`, `Q(workspace__created_by=...)`, and `Q(workspace__collaborators=...)` in `backend/notes/views.py`.
- Switched create-time authorization to use the workspace-level source of truth by validating with `Workspace.objects.accessible_to(...)` in `TodoListViewSet.perform_create` and `NoteViewSet.perform_create` so members of a shared workspace may create child items without additional per-item sharing.
- Updated `NoteSerializer.validate` in `backend/notes/serializers.py` to treat workspace membership as granting permission to attach or create notes in a todo list, preserving item-level collaborators as additive sharing.
- Added tests to `backend/notes/tests.py` that verify workspace collaborators can retrieve owner-created child todo lists and notes, owners can retrieve collaborator-created child items, collaborators can create workspace-scoped notes, and that cross-workspace access does not leak; and updated `CHANGELOG.md`.

### Testing
- Ran `python backend/manage.py test notes` and all tests succeeded (45 tests ran and passed).
- The added tests exercise creation and retrieval flows for owner, collaborator, and outsider scenarios and passed under the updated access rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a434ad027788333bde4e8dadacbb819)