### PR TITLE
Stabilize local Docker and checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,8 @@ Use the same script as the Codex maintenance script so cached containers refresh
 5) For local Docker runs that should use the current checkout rather than published GHCR images, rebuild first:
    - `docker build -t ghcr.io/vanillaicecube/notoli-backend:latest ./backend`
    - `docker build --build-arg REACT_APP_API_BASE_URL= -t ghcr.io/vanillaicecube/notoli-frontend:latest ./frontend`
+   - The backend image uses the maintained `condaforge/miniforge3` base image.
+   - The frontend image uses `npm ci`, so keep `frontend/package-lock.json` in sync with `frontend/package.json`.
 6) The included reverse proxy serves the production frontend at `https://notoli.judeandrewalaba.com/` when local DNS/hosts point that name at your machine. HTTP redirects to HTTPS.
    Backend is exposed on the direct port:
    - `http://localhost:8000`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-07-03
+### Fixed
+- Removed obsolete Docker Compose and Nginx HTTP/2 syntax warnings from local/proxy startup.
+- Switched the backend Docker image to the maintained `condaforge/miniforge3` base image.
+- Made frontend Prettier checks pass on Windows checkouts that use Git's default CRLF working-tree conversion.
+### Changed
+- Made frontend Docker builds use `npm ci` for lockfile-reproducible installs.
+- Applied existing backend Ruff and frontend Prettier formatting so local format checks pass.
+
 ## 2026-06-30
 ### Fixed
 - Made shared workspace membership sufficient to retrieve newly created child todo lists and notes while preserving item-level collaborator access as additive sharing.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3
+FROM condaforge/miniforge3
 
 # Set working directory
 WORKDIR /backend

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,6 +8,9 @@ Docker Compose (`deploy/docker-compose.yml`) starts:
 - `backend`: Django/Gunicorn (port 8000)
 - `frontend`: Nginx serving the built SPA (port 3000)
 
+The compose file uses the current Compose Specification syntax without a top-level
+`version` field.
+
 ## TLS Certificates (Required For The Proxy)
 The reverse proxy expects these files to exist on the host:
 - `certs/origin.pem`
@@ -83,6 +86,10 @@ docker build -t ghcr.io/vanillaicecube/notoli-backend:latest ./backend
 docker build --build-arg REACT_APP_API_BASE_URL= \
   -t ghcr.io/vanillaicecube/notoli-frontend:latest ./frontend
 ```
+
+The backend image builds from the maintained `condaforge/miniforge3` base image.
+The frontend image uses `npm ci`, so `frontend/package-lock.json` must stay in sync
+with `frontend/package.json`.
 
 5. Start the stack:
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   proxy:
     image: nginx:alpine

--- a/deploy/nginx-proxy.conf
+++ b/deploy/nginx-proxy.conf
@@ -13,8 +13,9 @@ server {
 }
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name notoli.judeandrewalaba.com;
 
   # Cloudflare Origin Certificate (mounted into the container)

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "printWidth": 100,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /frontend
 
 # Copy package.json and package-lock.json and install Node.js dependencies
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # Copy your React project code
 COPY . .


### PR DESCRIPTION
## Summary
- stabilize local Docker startup by removing obsolete Compose syntax and updating Nginx HTTP/2 config
- move the backend image to `condaforge/miniforge3` and make frontend Docker installs use `npm ci`
- make frontend Prettier checks work on Windows CRLF checkouts without broad line-ending churn
- update setup/deploy docs and changelog

Fixes #476

## Validation
- `python manage.py test --verbosity=2` from `backend/`: 80 passed
- `python -m ruff check .` and `python -m ruff format --check .` from `backend/`: passed
- `npm test -- --watchAll=false --runInBand` from `frontend/`: 19 suites / 173 tests passed
- `npm run lint:strict`, `npm run format:check`, and `npm run build` from `frontend/`: passed
- `docker build -t ghcr.io/vanillaicecube/notoli-backend:latest ./backend`: passed
- `docker build --build-arg REACT_APP_API_BASE_URL= -t ghcr.io/vanillaicecube/notoli-frontend:latest ./frontend`: passed
- `docker compose up -d --force-recreate` from `deploy/`: passed
- `curl -k -I -H "Host: notoli.judeandrewalaba.com" https://localhost/`: 200 OK
- `curl -k -I -H "Host: notoli.judeandrewalaba.com" https://localhost/api/`: expected 401 Unauthorized