### PR TITLE
Restrict shared board collaborator write actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Added a CodeQL analysis workflow for backend Python, frontend JavaScript/TypeScript, and GitHub Actions workflow scanning.
 ### Fixed
+- Returned explicit 403 details when shared board collaborators try to update or delete board metadata.
 - Made shared board collaborator access read-only in the sharing dialog without presenting invite or remove controls.
 - Added regression coverage for collaborator attempts to remove board collaborators.
 ### Changed

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,7 @@ All `/api/*` endpoints require:
 Access scoping:
 - Board membership is the source of truth for access. `Board.owner` and `Board.collaborators` control access to child lists and notes.
 - Lists and notes keep `created_by` metadata, but do not have separate owner or collaborator fields.
+- Board owners can update board metadata and delete boards; collaborators receive a 403 response for board `PATCH`/`DELETE` attempts while retaining read access to shared boards.
 - Board owners can manage board collaborators with `POST /api/boards/<id>/collaborators/` using `{ "identifier": "<username-or-email>" }` and `DELETE /api/boards/<id>/collaborators/<user_id>/`.
 - Board responses include `owner_details` and `collaborators_details` summaries for sharing/access UI.
 - Lists are returned in their saved board order. Persist a new board order with `PATCH /api/lists/reorder/` and `{ "board": <id>, "ordered_ids": [<list-id>, ...] }`.

--- a/backend/notes/tests.py
+++ b/backend/notes/tests.py
@@ -286,6 +286,9 @@ class BoardApiTests(APITestCase):
             status.HTTP_403_FORBIDDEN,
             f"Expected 403 when collaborator updates board, got {response.status_code}: {response.data}",
         )
+        self.assertEqual(
+            response.data.get("detail"), "Only the board owner can update this board."
+        )
         self.board.refresh_from_db()
         self.assertEqual(self.board.name, "Owner Board")
 
@@ -308,6 +311,9 @@ class BoardApiTests(APITestCase):
             response.status_code,
             status.HTTP_403_FORBIDDEN,
             f"Expected 403 when collaborator deletes board, got {response.status_code}: {response.data}",
+        )
+        self.assertEqual(
+            response.data.get("detail"), "Only the board owner can delete this board."
         )
         self.assertTrue(Board.objects.filter(pk=self.board.pk).exists())
 

--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -85,16 +85,18 @@ class BoardViewSet(viewsets.ModelViewSet):
         serializer.save(owner=self.request.user, created_by=self.request.user)
 
     def perform_update(self, serializer):
-        self._require_owner(serializer.instance)
+        self._require_owner(
+            serializer.instance, "Only the board owner can update this board."
+        )
         serializer.save()
 
     def perform_destroy(self, instance):
-        self._require_owner(instance)
+        self._require_owner(instance, "Only the board owner can delete this board.")
         instance.delete()
 
-    def _require_owner(self, board):
+    def _require_owner(self, board, message="Only the board owner can manage access."):
         if board.owner_id != self.request.user.id:
-            raise PermissionDenied("Only the board owner can manage access.")
+            raise PermissionDenied(message)
 
     def _find_collaborator(self, identifier):
         identifier = identifier.strip() if isinstance(identifier, str) else ""


### PR DESCRIPTION
### Motivation
- Prevent shared collaborators from renaming or deleting a board by ensuring workspace/board update and delete actions are owner-gated and return a clear 403 response.

### Description
- Updated `BoardViewSet.perform_update` and `perform_destroy` to call `_require_owner` with explicit owner-only messages and changed `_require_owner` to accept a `message` parameter and raise `PermissionDenied(message)`.
- Extended backend regression tests in `backend/notes/tests.py` to assert collaborator `PATCH` and `DELETE` attempts return 403 and include the expected `detail` messages for update and delete.
- Documented collaborator read-only behavior in `backend/README.md` and added a changelog entry describing the explicit 403 details for collaborator write attempts.

### Testing
- Ran `python backend/manage.py test notes.tests.BoardApiTests` (including the collaborator `PATCH`/`DELETE` tests) and all tests passed.
- Ran `python -m ruff check backend/notes/views.py backend/notes/tests.py` and `python -m ruff format --check backend/notes/views.py backend/notes/tests.py`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3a306d848333990dde5fc48c36fe)