### PR TITLE
Fix HTTP 500 when creating lists

### DIFF
--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import Max, Q
@@ -22,6 +24,7 @@ from .models import List as NoteList
 from .serializers import BoardSerializer, ListSerializer, NoteSerializer
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 def _require_board_access(user, board_id):
@@ -266,15 +269,23 @@ class ListViewSet(viewsets.ModelViewSet):
             position=next_position,
         )
         note_list = serializer.instance
-        notify_board_members(
-            board,
-            self.request.user,
-            Notification.EVENT_LIST_CREATED,
-            f"New list in {board.name}",
-            f'{display_name(self.request.user)} created the list "{note_list.name}".',
-            note_list=note_list,
-            target_path=list_path(note_list),
-        )
+        try:
+            notify_board_members(
+                board,
+                self.request.user,
+                Notification.EVENT_LIST_CREATED,
+                f"New list in {board.name}",
+                f'{display_name(self.request.user)} created the list "{note_list.name}".',
+                note_list=note_list,
+                target_path=list_path(note_list),
+            )
+        except Exception:
+            # A notification failure must not turn a successful list write into a
+            # misleading 500 response. The list is already persisted, so log the
+            # failure and let the API return the created resource.
+            logger.exception(
+                "List creation notification failed for list_id=%s", note_list.pk
+            )
 
     def perform_update(self, serializer):
         note_list = serializer.save()

--- a/backend/notifications/tests.py
+++ b/backend/notifications/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -273,6 +275,29 @@ class NotificationApiTests(APITestCase):
             notification.target_path,
             f"/board/{self.board.id}/list/{notification.list_id}",
         )
+
+    @patch(
+        "notes.views.notify_board_members",
+        side_effect=Exception("notifications table is unavailable"),
+    )
+    def test_list_create_succeeds_when_notification_fails(self, mock_notify):
+        self.client.force_authenticate(user=self.collaborator)
+        with self.assertLogs("notes.views", level="ERROR") as logs:
+            response = self.client.post(
+                "/api/lists/",
+                {
+                    "name": "List Without Notification",
+                    "description": "The list must still be created.",
+                    "board": self.board.id,
+                },
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        created_list = List.objects.get(name="List Without Notification")
+        self.assertEqual(response.data["id"], created_list.id)
+        mock_notify.assert_called_once()
+        self.assertIn("List creation notification failed", logs.output[0])
 
     def test_owner_board_rename_notifies_collaborators(self):
         self.client.force_authenticate(user=self.owner)


### PR DESCRIPTION
## Summary
- prevent notification persistence failures from converting a successful list creation into an HTTP 500 response
- log notification failures with the created list ID for follow-up
- add regression coverage for notification failures during list creation

## Root cause
The list was saved before `notify_board_members()` ran. If notification storage failed (for example, due to unapplied notification migrations), the API returned HTTP 500 even though the list persisted and appeared after refresh.

## Validation
- `python backend/manage.py test authentication notes notifications --verbosity 1`
- `npm test -- --watchAll=false --runInBand`

Closes #548