### PR TITLE
Align CodeQL pull-request scope and Actions coverage

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -33,7 +33,9 @@ Version pins:
 
 CodeQL details:
 - Pull requests run CodeQL through `ci.yml`, keeping PR feedback under the main CI workflow.
-- Pull request scans use path filtering so unrelated changes avoid the expensive language analysis jobs.
+- Pull request CodeQL uses the reusable workflow's change-detection job, following the same skip-by-scope pattern as linting and testing; documentation-only and unrelated pull requests run the detector but skip analysis jobs.
+- For a CodeQL-relevant pull request, Python and JavaScript/TypeScript analysis use language-specific filters, while GitHub Actions analysis runs so the `/language:actions` configuration remains present for code-scanning comparisons.
+- CI ignores pull requests targeting `env-prod`, so CodeQL is not invoked for that deployment branch.
 - Pushes to `main`, weekly scheduled scans, and manual `workflow_dispatch` runs are supported directly by `codeql.yml`.
 - CodeQL uploads SARIF results to GitHub Code Scanning with scoped permissions: `contents: read`, `pull-requests: read`, `actions: read`, and `security-events: write`.
 - Results appear in PR checks and under GitHub Security -> Code scanning when code scanning is enabled for the repository.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,15 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "python=${{ steps.filter.outputs.python }}" >> "$GITHUB_OUTPUT"
             echo "javascript=${{ steps.filter.outputs.javascript }}" >> "$GITHUB_OUTPUT"
-            echo "actions=${{ steps.filter.outputs.actions }}" >> "$GITHUB_OUTPUT"
+            # Keep the Actions configuration present for relevant PRs so
+            # GitHub can compare it with the configuration on the base branch.
+            if [ "${{ steps.filter.outputs.actions }}" = "true" ] || \
+               [ "${{ steps.filter.outputs.python }}" = "true" ] || \
+               [ "${{ steps.filter.outputs.javascript }}" = "true" ]; then
+              echo "actions=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "actions=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "python=true" >> "$GITHUB_OUTPUT"
             echo "javascript=true" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Added notification board/list/note navigation context and `target_path` routing metadata for shared board activity.
 - Added completion-specific shared note notifications when a note transitions to `Complete`.
 ### Fixed
+- Matched CodeQL pull-request scope detection to the lint/test pattern, skipping analysis for unrelated changes and retaining the Actions configuration for relevant PR comparisons.
 - Prevented repeated saves of an already-complete note from creating duplicate completion notifications.
 - Confirmed duplicate collaborator-add attempts do not create extra notifications.
 ### Changed


### PR DESCRIPTION
## Summary

- Align CodeQL pull-request scope detection with the lint/test pattern.
- Skip language analysis jobs for unrelated or documentation-only changes.
- Keep `/language:actions` analysis present for CodeQL-relevant PRs to avoid missing comparison configurations.
- Document the behavior, including the existing exclusion for PRs targeting `env-prod`.

## Root cause

The reusable CodeQL workflow filtered each language independently, which could omit the GitHub Actions analysis configuration while Python or JavaScript/TypeScript analysis still ran. That produced a neutral code-scanning result reporting a missing `/language:actions` configuration.

## Validation

- Parsed `.github/workflows/ci.yml` and `.github/workflows/codeql.yml` with PyYAML.
- Ran `git diff --check`.

Closes #544
Closes #554