### PR TITLE
Add dependency vulnerability and malware gates

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -16,11 +16,16 @@ What it does:
   - Python/Django backend analysis for `backend/**`
   - JavaScript/TypeScript frontend analysis for `frontend/**`
   - GitHub Actions workflow analysis for `.github/workflows/**` and `.github/actions/**`
+- Runs the reusable vulnerability review: [`.github/workflows/vulnerability.yml`](workflows/vulnerability.yml)
+  - Uses GitHub Dependency Review and fails when a PR introduces a high or critical vulnerability.
+- Runs the reusable malware review: [`.github/workflows/malware.yml`](workflows/malware.yml)
+  - Uses the local [npm malware review action](actions/review-npm-malware/action.yml) to compare changed `frontend/package-lock.json` packages against GitHub's npm malware advisories.
+  - Updates one PR summary comment and fails when a changed package/version matches a known malware advisory.
 - For non-Dependabot PRs, runs [`.github/workflows/commentary.yml`](workflows/commentary.yml)
   - Generates an OpenAI-written PR summary and PR review
   - Posts the summary to the PR description or as a comment
   - Creates a PR review with up to 6 inline comments (when line placement is valid)
-- For Dependabot PRs, runs [`.github/workflows/auto_merge.yml`](workflows/auto_merge.yml) (only if lints + tests pass)
+- For Dependabot PRs, runs [`.github/workflows/auto_merge.yml`](workflows/auto_merge.yml) only when lints, tests, vulnerability review, and malware review pass.
 
 OpenAI inputs (commentary workflow):
 - `OPENAI_API_KEY` (optional secret)
@@ -43,8 +48,11 @@ CodeQL details:
 - CodeQL is not a scanner for Dockerfiles, Nginx config, or env example files. Those remain covered by Dependabot updates, review, and deployment validation unless a separate scanner is added.
 
 Merge blocking:
+- The active `main` ruleset requires the Vulnerability and Malware checks alongside the existing lint, test, and CodeQL checks.
+- Dependency vulnerability review fails at `high` severity or above and posts its summary directly on the PR.
+- Dependency malware review is npm-focused because GitHub's malware advisory coverage is currently npm-focused; it checks only changed lockfile package versions.
 - The workflow reports CodeQL findings, but this repository has not intentionally made CodeQL a Dependabot auto-merge prerequisite in `auto_merge.yml` yet.
-- Dependabot auto-merge still requires the existing lint and test jobs to pass. CodeQL runs in the same CI graph so its check is visible before merge decisions, but the auto-merge condition only checks lints and tests.
+- Dependabot auto-merge requires lint, test, vulnerability, and malware checks to pass. CodeQL runs in the same CI graph so its check is visible before merge decisions, but it is not an auto-merge prerequisite.
 - To make serious CodeQL findings block merges, configure GitHub branch protection or a repository ruleset to require the relevant CodeQL check after validating runtime and alert noise.
 - Recommended staged policy: block high/critical security findings first; allow medium, low, and note-level findings to report until the false-positive rate is understood.
 - When code fixes remove a finding, GitHub closes the matching code scanning alert after the protected branch is reanalyzed. False positives or accepted risks should be dismissed in GitHub Code Scanning with a clear reason.

--- a/.github/actions/review-npm-malware/action.yml
+++ b/.github/actions/review-npm-malware/action.yml
@@ -1,0 +1,145 @@
+name: Review npm malware
+description: Fails when changed npm lockfile packages match GitHub malware advisories.
+
+inputs:
+  base-sha:
+    description: Pull request base commit SHA.
+    required: true
+  head-sha:
+    description: Pull request head commit SHA.
+    required: true
+  github-token:
+    description: Token used to query GitHub's Advisory Database.
+    required: true
+  report-path:
+    description: Absolute path for the Markdown review report.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install semver matcher
+      shell: bash
+      run: |
+        npm install --global --ignore-scripts semver@7.7.3
+        echo "NODE_PATH=$(npm root --global)" >> "$GITHUB_ENV"
+
+    - name: Review changed npm packages
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        REPORT_PATH: ${{ inputs.report-path }}
+      run: |
+        git show "$BASE_SHA:frontend/package-lock.json" > "$RUNNER_TEMP/base-package-lock.json"
+        git show "$HEAD_SHA:frontend/package-lock.json" > "$RUNNER_TEMP/head-package-lock.json"
+
+        node <<'NODE'
+        const fs = require('fs');
+        const semver = require('semver');
+
+        const baseLockPath = `${process.env.RUNNER_TEMP}/base-package-lock.json`;
+        const headLockPath = `${process.env.RUNNER_TEMP}/head-package-lock.json`;
+        const reportPath = process.env.REPORT_PATH;
+
+        function readLock(path) {
+          return JSON.parse(fs.readFileSync(path, 'utf8')).packages || {};
+        }
+
+        function packageNameFromPath(path) {
+          const marker = 'node_modules/';
+          const index = path.lastIndexOf(marker);
+          if (index < 0) return null;
+          const parts = path.slice(index + marker.length).split('/');
+          return parts[0].startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+        }
+
+        function changedPackages(base, head) {
+          const changes = new Map();
+          for (const [path, entry] of Object.entries(head)) {
+            if (!entry?.version) continue;
+            const name = packageNameFromPath(path);
+            if (!name) continue;
+            if (base[path]?.version !== entry.version) {
+              changes.set(`${name}@${entry.version}`, { name, version: entry.version });
+            }
+          }
+          return [...changes.values()];
+        }
+
+        async function fetchMalwareAdvisories() {
+          const advisories = [];
+          for (let page = 1; ; page += 1) {
+            const url = new URL('https://api.github.com/advisories');
+            url.searchParams.set('ecosystem', 'npm');
+            url.searchParams.set('type', 'malware');
+            url.searchParams.set('per_page', '100');
+            url.searchParams.set('page', String(page));
+            const response = await fetch(url, {
+              headers: {
+                Accept: 'application/vnd.github+json',
+                Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                'X-GitHub-Api-Version': '2022-11-28',
+              },
+            });
+            if (!response.ok) throw new Error(`GitHub Advisory API returned ${response.status}`);
+            const results = await response.json();
+            advisories.push(...results);
+            if (results.length < 100) return advisories;
+          }
+        }
+
+        function findingsFor(packages, advisories) {
+          const findings = [];
+          for (const advisory of advisories) {
+            for (const vulnerability of advisory.vulnerabilities || []) {
+              const name = vulnerability.package?.name;
+              const range = vulnerability.vulnerable_version_range;
+              if (!name || !range) continue;
+              for (const dependency of packages.filter((item) => item.name === name)) {
+                if (semver.valid(dependency.version) && semver.satisfies(dependency.version, range, { includePrerelease: true })) {
+                  findings.push({
+                    name: dependency.name,
+                    version: dependency.version,
+                    ghsa: advisory.ghsa_id,
+                    summary: advisory.summary,
+                    url: advisory.html_url,
+                  });
+                }
+              }
+            }
+          }
+          return [...new Map(findings.map((item) => [`${item.name}@${item.version}:${item.ghsa}`, item])).values()];
+        }
+
+        async function main() {
+          const packages = changedPackages(readLock(baseLockPath), readLock(headLockPath));
+          if (packages.length === 0) {
+            fs.writeFileSync(reportPath, '### Malware\n\nNo npm dependency changes were found in this pull request.');
+            return;
+          }
+
+          const findings = findingsFor(packages, await fetchMalwareAdvisories());
+          if (findings.length === 0) {
+            fs.writeFileSync(reportPath, '### Malware\n\n✅ No changed npm dependency matches a known GitHub malware advisory.');
+            return;
+          }
+
+          fs.writeFileSync(reportPath, [
+            '### Malware',
+            '',
+            '❌ This pull request changes npm dependencies with known malware advisories:',
+            '',
+            ...findings.map((item) => `- **${item.name}@${item.version}** — [${item.ghsa}](${item.url}): ${item.summary}`),
+            '',
+            'Remove or replace the affected dependency before merging.',
+          ].join('\n'));
+          process.exitCode = 1;
+        }
+
+        main().catch((error) => {
+          fs.writeFileSync(reportPath, `### Malware\n\n❌ Review failed: ${error.message}`);
+          process.exitCode = 1;
+        });
+        NODE

--- a/.github/actions/review-npm-malware/action.yml
+++ b/.github/actions/review-npm-malware/action.yml
@@ -43,6 +43,20 @@ runs:
         const headLockPath = `${process.env.RUNNER_TEMP}/head-package-lock.json`;
         const reportPath = process.env.REPORT_PATH;
 
+        const escapeHtml = (value) => String(value ?? '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+
+        const report = (content) => [
+          '<h1>Malware Review</h1>',
+          content,
+          '<h2>Scanned Files</h2>',
+          '<ul><li><code>frontend/package-lock.json</code></li></ul>',
+        ].join('\n');
+
         function readLock(path) {
           return JSON.parse(fs.readFileSync(path, 'utf8')).packages || {};
         }
@@ -116,30 +130,46 @@ runs:
         async function main() {
           const packages = changedPackages(readLock(baseLockPath), readLock(headLockPath));
           if (packages.length === 0) {
-            fs.writeFileSync(reportPath, '### Malware\n\nNo npm dependency changes were found in this pull request.');
+            fs.writeFileSync(reportPath, report([
+              'The following issues were found:',
+              '<ul><li>✅ 0 changed npm package(s) to review.</li></ul>',
+            ].join('\n')));
             return;
           }
 
           const findings = findingsFor(packages, await fetchMalwareAdvisories());
           if (findings.length === 0) {
-            fs.writeFileSync(reportPath, '### Malware\n\n✅ No changed npm dependency matches a known GitHub malware advisory.');
+            fs.writeFileSync(reportPath, report([
+              'The following issues were found:',
+              '<ul><li>✅ 0 changed npm package(s) matching known GitHub malware advisories.</li></ul>',
+            ].join('\n')));
             return;
           }
 
-          fs.writeFileSync(reportPath, [
-            '### Malware',
-            '',
-            '❌ This pull request changes npm dependencies with known malware advisories:',
-            '',
-            ...findings.map((item) => `- **${item.name}@${item.version}** — [${item.ghsa}](${item.url}): ${item.summary}`),
-            '',
-            'Remove or replace the affected dependency before merging.',
-          ].join('\n'));
+          const rows = findings.map((item) => [
+            '<tr>',
+            `<td><code>${escapeHtml(item.name)}</code></td>`,
+            `<td><code>${escapeHtml(item.version)}</code></td>`,
+            `<td><a href="${escapeHtml(item.url)}">${escapeHtml(item.ghsa)}</a></td>`,
+            `<td>${escapeHtml(item.summary)}</td>`,
+            '</tr>',
+          ].join('')).join('\n');
+          fs.writeFileSync(reportPath, report([
+            'The following issues were found:',
+            `<ul><li>❌ ${findings.length} changed npm package(s) matching known GitHub malware advisories.</li></ul>`,
+            '<h2>Malware Issues</h2>',
+            '<table><thead><tr><th>Package</th><th>Version</th><th>Advisory</th><th>Details</th></tr></thead><tbody>',
+            rows,
+            '</tbody></table>',
+          ].join('\n')));
           process.exitCode = 1;
         }
 
         main().catch((error) => {
-          fs.writeFileSync(reportPath, `### Malware\n\n❌ Review failed: ${error.message}`);
+          fs.writeFileSync(reportPath, report([
+            'The following issues were found:',
+            `<ul><li>❌ Malware review failed: ${escapeHtml(error.message)}</li></ul>`,
+          ].join('\n')));
           process.exitCode = 1;
         });
         NODE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,23 @@ jobs:
       pull-requests: read
       security-events: write
 
+  dependency-vulnerability:
+    name: Vulnerability
+    uses: ./.github/workflows/vulnerability.yml
+    permissions:
+      contents: read
+      pull-requests: write
+
+  dependency-malware:
+    name: Malware
+    uses: ./.github/workflows/malware.yml
+    permissions:
+      contents: read
+      pull-requests: write
+
   commentary:
     name: Commentary
-    needs: [lints, tests, codeql]
+    needs: [lints, tests, codeql, dependency-vulnerability, dependency-malware]
     if: >-
       always() &&
       github.event.pull_request.user.login != 'dependabot[bot]'
@@ -55,12 +69,14 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [lints, tests, codeql]
+    needs: [lints, tests, codeql, dependency-vulnerability, dependency-malware]
     if: >-
       always() &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       needs.lints.result == 'success' &&
-      needs.tests.result == 'success'
+      needs.tests.result == 'success' &&
+      needs.dependency-vulnerability.result == 'success' &&
+      needs.dependency-malware.result == 'success'
     uses: ./.github/workflows/auto_merge.yml
     permissions:
       contents: write

--- a/.github/workflows/malware.yml
+++ b/.github/workflows/malware.yml
@@ -1,0 +1,61 @@
+name: Malware
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  malware:
+    name: Malware
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Review changed npm packages
+        id: malware
+        continue-on-error: true
+        uses: ./.github/actions/review-npm-malware
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          github-token: ${{ github.token }}
+          report-path: ${{ runner.temp }}/malware-report.md
+
+      - name: Publish PR summary
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          REPORT_PATH: ${{ runner.temp }}/malware-report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- notoli-malware-review -->';
+            const report = fs.existsSync(process.env.REPORT_PATH)
+              ? fs.readFileSync(process.env.REPORT_PATH, 'utf8').trim()
+              : 'The malware review did not produce a report.';
+            const body = `${marker}\n${report}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Fail when malware is found
+        if: steps.malware.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -1,0 +1,22 @@
+name: Vulnerability
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vulnerability:
+    name: Vulnerability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Review vulnerable dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project are documented in this file.
 
 ## 2026-07-10
 ### Added
+- Added PR-time dependency vulnerability and npm malware gates to the reusable CI flow.
+- Added PR-visible malware summaries and dependency checks to Dependabot auto-merge prerequisites.
 - Added notification board/list/note navigation context and `target_path` routing metadata for shared board activity.
 - Added completion-specific shared note notifications when a note transitions to `Complete`.
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It's designed to support **multiple views** of the same list, so my wife, Diana,
 - **DNS/Proxy:** Cloudflare
 - **TLS:** Cloudflare Full (strict) to origin (Cloudflare Origin Certificate)
 - **CI/CD & Workflows:** GitHub Actions
+- **PR dependency gates:** high/critical vulnerability review and npm malware advisory review
 
 ## 📚 Documentation
 - Setup, Codex cloud environment settings, env vars, and common commands: [`AGENTS.md`](AGENTS.md)


### PR DESCRIPTION
## Summary
- add a high/critical dependency vulnerability PR gate using GitHub Dependency Review
- add an npm malware PR gate backed by GitHub Advisory Database malware advisories
- make both gates required for `main` and prerequisites for Dependabot auto-merge

## Implementation
- reusable `Vulnerability` and `Malware` workflows are called from CI
- a local composite action compares changed `frontend/package-lock.json` packages with known malware advisories and updates a single PR comment
- documentation and changelog describe the new gate behavior

## Validation
- parsed all changed workflow and action YAML
- checked the composite action's Node logic against the current lockfile
- ran `git diff --check`

Closes #540
Closes #541