### PR TITLE
Optimize CI checks and update GPT model

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -12,6 +12,11 @@ What it does:
 - Runs the reusable test workflow: [`.github/workflows/tests.yml`](workflows/tests.yml)
   - Frontend: `npm test` (CI mode)
   - Backend: `python manage.py test`
+- Lint and test jobs use the same change filters:
+  - Frontend checks run for `frontend/**` changes.
+  - Backend checks run for `backend/**` changes.
+  - Changes under `.github/workflows/**` or `.github/actions/**` run both frontend and backend checks because shared CI behavior may affect either stack.
+  - Jobs skipped because their paths are not relevant report `not-applicable` to PR commentary.
 - Runs the reusable CodeQL workflow: [`.github/workflows/codeql.yml`](workflows/codeql.yml)
   - Python/Django backend analysis for `backend/**`
   - JavaScript/TypeScript frontend analysis for `frontend/**`
@@ -30,6 +35,7 @@ What it does:
 OpenAI inputs (commentary workflow):
 - `OPENAI_API_KEY` (optional secret)
 - `OPENAI_PROJECT_ID` (repo variable)
+- PR summaries and AI reviews use `gpt-5.5` through the local OpenAI Chat Completions action.
 
 Version pins:
 - Node version is read from `frontend/package.json` (`engines.node`)

--- a/.github/actions/openai-chat/action.yml
+++ b/.github/actions/openai-chat/action.yml
@@ -20,7 +20,7 @@ inputs:
   model:
     description: OpenAI model name.
     required: false
-    default: "gpt-5.1"
+    default: "gpt-5.5"
   temperature:
     description: Sampling temperature.
     required: false

--- a/.github/workflows/commentary.yml
+++ b/.github/workflows/commentary.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       lint_frontend_status:
-        description: Frontend lint status (success/failure/none).
+        description: Frontend lint status (success/failure/not-applicable).
         required: false
         type: string
       lint_frontend_log:
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       lint_backend_status:
-        description: Backend lint status (success/failure/none).
+        description: Backend lint status (success/failure/not-applicable).
         required: false
         type: string
       lint_backend_log:
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       test_frontend_status:
-        description: Frontend test status (success/failure/none).
+        description: Frontend test status (success/failure/not-applicable).
         required: false
         type: string
       test_frontend_log:
@@ -28,7 +28,7 @@ on:
         required: false
         type: string
       test_backend_status:
-        description: Backend test status (success/failure/none).
+        description: Backend test status (success/failure/not-applicable).
         required: false
         type: string
       test_backend_log:
@@ -75,7 +75,7 @@ jobs:
           api_key: ${{ secrets.OPENAI_API_KEY }}
           project_id: ${{ vars.OPENAI_PROJECT_ID }}
           diff_path: ${{ steps.pr_diff.outputs.diff_path }}
-          model: "gpt-5.1"
+          model: "gpt-5.5"
           temperature: "0.3"
           system_prompt: "You are an experienced PR summarizer helping on GitHub pull requests."
           prompt_prefix: |
@@ -143,7 +143,7 @@ jobs:
           api_key: ${{ secrets.OPENAI_API_KEY }}
           project_id: ${{ vars.OPENAI_PROJECT_ID }}
           diff_path: ${{ steps.pr_diff.outputs.linediff_path }}
-          model: "gpt-5.1"
+          model: "gpt-5.5"
           temperature: "0.2"
           system_prompt: "You are an experienced, pragmatic PR reviewer."
           prompt_prefix: |
@@ -166,10 +166,10 @@ jobs:
             - If the diff is truncated, mention it in the body.
 
             CI context (lint/test results):
-            - lint_frontend_status: ${{ inputs.lint_frontend_status || 'none' }}
-            - lint_backend_status: ${{ inputs.lint_backend_status || 'none' }}
-            - test_frontend_status: ${{ inputs.test_frontend_status || 'none' }}
-            - test_backend_status: ${{ inputs.test_backend_status || 'none' }}
+            - lint_frontend_status: ${{ inputs.lint_frontend_status || 'not-applicable' }}
+            - lint_backend_status: ${{ inputs.lint_backend_status || 'not-applicable' }}
+            - test_frontend_status: ${{ inputs.test_frontend_status || 'not-applicable' }}
+            - test_backend_status: ${{ inputs.test_backend_status || 'not-applicable' }}
             - lint_frontend_log (tail):
             ${{ inputs.lint_frontend_log }}
             - lint_backend_log (tail):

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,17 +9,17 @@ on:
         type: string
     outputs:
       lint_frontend_status:
-        description: Frontend lint status (success/failure/none).
-        value: ${{ jobs.lint-frontend.outputs.status }}
+        description: Frontend lint status (success/failure/not-applicable).
+        value: ${{ jobs.lint-results.outputs.frontend_status }}
       lint_frontend_log:
         description: Frontend lint log tail.
-        value: ${{ jobs.lint-frontend.outputs.log }}
+        value: ${{ jobs.lint-results.outputs.frontend_log }}
       lint_backend_status:
-        description: Backend lint status (success/failure/none).
-        value: ${{ jobs.lint-backend.outputs.status }}
+        description: Backend lint status (success/failure/not-applicable).
+        value: ${{ jobs.lint-results.outputs.backend_status }}
       lint_backend_log:
         description: Backend lint log tail.
-        value: ${{ jobs.lint-backend.outputs.log }}
+        value: ${{ jobs.lint-results.outputs.backend_log }}
 
 concurrency:
   group: lint-${{ github.ref }}
@@ -46,8 +46,12 @@ jobs:
           filters: |
             frontend:
               - 'frontend/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
             backend:
               - 'backend/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
 
   lint-frontend:
     name: Lint Frontend (ESLint + Prettier)
@@ -248,3 +252,56 @@ jobs:
     outputs:
       status: ${{ steps.lint_summary.outputs.status }}
       log: ${{ steps.lint_summary.outputs.log }}
+
+  lint-results:
+    name: Lint Results
+    if: always()
+    needs: [changes, lint-frontend, lint-backend]
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_status: ${{ steps.results.outputs.frontend_status }}
+      frontend_log: ${{ steps.results.outputs.frontend_log }}
+      backend_status: ${{ steps.results.outputs.backend_status }}
+      backend_log: ${{ steps.results.outputs.backend_log }}
+    steps:
+      - name: Normalize lint results
+        id: results
+        env:
+          FRONTEND_RELEVANT: ${{ needs.changes.outputs.frontend }}
+          FRONTEND_STATUS: ${{ needs.lint-frontend.outputs.status }}
+          FRONTEND_LOG: ${{ needs.lint-frontend.outputs.log }}
+          BACKEND_RELEVANT: ${{ needs.changes.outputs.backend }}
+          BACKEND_STATUS: ${{ needs.lint-backend.outputs.status }}
+          BACKEND_LOG: ${{ needs.lint-backend.outputs.log }}
+        shell: bash
+        run: |
+          if [ "$FRONTEND_RELEVANT" = "true" ]; then
+            echo "frontend_status=${FRONTEND_STATUS:-failure}" >> "$GITHUB_OUTPUT"
+            {
+              echo 'frontend_log<<EOF'
+              echo "$FRONTEND_LOG"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend_status=not-applicable" >> "$GITHUB_OUTPUT"
+            echo "frontend_log=No frontend-relevant changes." >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$BACKEND_RELEVANT" = "true" ]; then
+            echo "backend_status=${BACKEND_STATUS:-failure}" >> "$GITHUB_OUTPUT"
+            {
+              echo 'backend_log<<EOF'
+              echo "$BACKEND_LOG"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "backend_status=not-applicable" >> "$GITHUB_OUTPUT"
+            echo "backend_log=No backend-relevant changes." >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$FRONTEND_RELEVANT" = "true" ] && [ "${FRONTEND_STATUS:-failure}" != "success" ]; then
+            exit 1
+          fi
+          if [ "$BACKEND_RELEVANT" = "true" ] && [ "${BACKEND_STATUS:-failure}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,25 +4,50 @@ on:
   workflow_call:
     outputs:
       test_frontend_status:
-        description: Frontend test status (success/failure/none).
-        value: ${{ jobs.frontend-tests.outputs.status }}
+        description: Frontend test status (success/failure/not-applicable).
+        value: ${{ jobs.test-results.outputs.frontend_status }}
       test_frontend_log:
         description: Frontend test log tail.
-        value: ${{ jobs.frontend-tests.outputs.log }}
+        value: ${{ jobs.test-results.outputs.frontend_log }}
       test_backend_status:
-        description: Backend test status (success/failure/none).
-        value: ${{ jobs.backend-tests.outputs.status }}
+        description: Backend test status (success/failure/not-applicable).
+        value: ${{ jobs.test-results.outputs.backend_status }}
       test_backend_log:
         description: Backend test log tail.
-        value: ${{ jobs.backend-tests.outputs.log }}
+        value: ${{ jobs.test-results.outputs.backend_log }}
 
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            backend:
+              - 'backend/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   frontend-tests:
     name: Frontend Tests (React)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -89,6 +114,8 @@ jobs:
 
   backend-tests:
     name: Backend Tests (Django)
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -150,3 +177,56 @@ jobs:
     outputs:
       status: ${{ steps.test_summary.outputs.status }}
       log: ${{ steps.test_summary.outputs.log }}
+
+  test-results:
+    name: Test Results
+    if: always()
+    needs: [changes, frontend-tests, backend-tests]
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_status: ${{ steps.results.outputs.frontend_status }}
+      frontend_log: ${{ steps.results.outputs.frontend_log }}
+      backend_status: ${{ steps.results.outputs.backend_status }}
+      backend_log: ${{ steps.results.outputs.backend_log }}
+    steps:
+      - name: Normalize test results
+        id: results
+        env:
+          FRONTEND_RELEVANT: ${{ needs.changes.outputs.frontend }}
+          FRONTEND_STATUS: ${{ needs.frontend-tests.outputs.status }}
+          FRONTEND_LOG: ${{ needs.frontend-tests.outputs.log }}
+          BACKEND_RELEVANT: ${{ needs.changes.outputs.backend }}
+          BACKEND_STATUS: ${{ needs.backend-tests.outputs.status }}
+          BACKEND_LOG: ${{ needs.backend-tests.outputs.log }}
+        shell: bash
+        run: |
+          if [ "$FRONTEND_RELEVANT" = "true" ]; then
+            echo "frontend_status=${FRONTEND_STATUS:-failure}" >> "$GITHUB_OUTPUT"
+            {
+              echo 'frontend_log<<EOF'
+              echo "$FRONTEND_LOG"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend_status=not-applicable" >> "$GITHUB_OUTPUT"
+            echo "frontend_log=No frontend-relevant changes." >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$BACKEND_RELEVANT" = "true" ]; then
+            echo "backend_status=${BACKEND_STATUS:-failure}" >> "$GITHUB_OUTPUT"
+            {
+              echo 'backend_log<<EOF'
+              echo "$BACKEND_LOG"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "backend_status=not-applicable" >> "$GITHUB_OUTPUT"
+            echo "backend_log=No backend-relevant changes." >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$FRONTEND_RELEVANT" = "true" ] && [ "${FRONTEND_STATUS:-failure}" != "success" ]; then
+            exit 1
+          fi
+          if [ "$BACKEND_RELEVANT" = "true" ] && [ "${BACKEND_STATUS:-failure}" != "success" ]; then
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ All notable changes to this project are documented in this file.
 - Added notification board/list/note navigation context and `target_path` routing metadata for shared board activity.
 - Added completion-specific shared note notifications when a note transitions to `Complete`.
 ### Fixed
+- Gated frontend and backend lint/test jobs by relevant path changes while keeping shared workflow and action changes covered.
+- Reported explicit `not-applicable` statuses for skipped lint and test scopes in PR commentary.
 - Matched CodeQL pull-request scope detection to the lint/test pattern, skipping analysis for unrelated changes and retaining the Actions configuration for relevant PR comparisons.
 - Prevented repeated saves of an already-complete note from creating duplicate completion notifications.
 - Confirmed duplicate collaborator-add attempts do not create extra notifications.
 ### Changed
+- Updated the PR summary and AI review workflows from GPT-5.1 to GPT-5.5.
 - Aligned the profile menu with the notification panel so both open inward from the right side of the app bar on mobile screens.
 - Simplified notification rows to a single event message with concise location context, clear actions, and dividers between notifications, including legacy messages that repeat the list name.
 - Added per-notification clearing while retaining the header action for marking all notifications read.


### PR DESCRIPTION
## Summary

- Gate frontend and backend lint/test jobs by relevant changed paths.
- Run both stacks for shared workflow and action changes.
- Report explicit `not-applicable` statuses for skipped scopes in PR commentary.
- Update the AI PR summary and review workflows from GPT-5.1 to GPT-5.5.

## Why

CI previously ran both test stacks for every pull request, while linting already had partial path filtering. This makes validation faster without reducing coverage for changes that can affect either stack.

## Validation

- YAML parsing passed for the edited workflows/actions.
- `git diff --check` passed.
