### PR TITLE
Polish navigation, branding, and sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,24 @@ All notable changes to this project are documented in this file.
 
 ## 2026-07-10
 ### Added
+- Added Notoli browser, install, and Apple-touch branding metadata with a native Notoli mark.
 - Added daily/manual LLM-based CodeQL, Dependabot vulnerability, and Dependabot malware alert aggregation workflows with validated, idempotent GitHub issue and project-field synchronization, repository-owner assignment, and gray feed tags.
 - Added PR-time dependency vulnerability and npm malware gates to the reusable CI flow.
 - Added PR-visible malware summaries and dependency checks to Dependabot auto-merge prerequisites.
 - Added notification board/list/note navigation context and `target_path` routing metadata for shared board activity.
 - Added completion-specific shared note notifications when a note transitions to `Complete`.
 ### Fixed
+- Prevented AppBar title flicker during list-to-board navigation by ignoring stale title requests.
+- Kept sharing access rows mounted through the dialog close transition.
+- Retried a request once after a successful access-token refresh and retained sessions during transient refresh failures.
 - Gated frontend and backend lint/test jobs by relevant path changes while keeping shared workflow and action changes covered.
 - Reported explicit `not-applicable` statuses for skipped lint and test scopes in PR commentary.
 - Matched CodeQL pull-request scope detection to the lint/test pattern, skipping analysis for unrelated changes and retaining the Actions configuration for relevant PR comparisons.
 - Prevented repeated saves of an already-complete note from creating duplicate completion notifications.
 - Confirmed duplicate collaborator-add attempts do not create extra notifications.
 ### Changed
+- Capitalized the generated default board suffix to `Board` for new users.
+- Themed the notes empty state and slowed the active pull-to-refresh spinner.
 - Renamed the security-alert workflow files to concise `alerts-*` and `security-alerts` names, and corrected their Dependabot and Project-token permission model.
 - Moved the security-alert implementation into a dedicated composite action so the reusable workflow remains a small orchestration layer.
 - Provisioned gray security feed labels with descriptions and removed label-management writes from the alert action.

--- a/backend/README.md
+++ b/backend/README.md
@@ -27,7 +27,7 @@ Common endpoints:
 - `POST /auth/forgot-password/` -> accepts `email`; sends a reset link if the account exists and returns a generic success message
 - `POST /auth/reset-password/` -> accepts `uid`, `token`, and `password`; sets a new password when the token is valid
 
-New users get a default board named after their username, such as `"andrew's board"`, created automatically via a post-save signal in `notes/signals.py`. If a username is unavailable, the name falls back to the email prefix.
+New users get a default board named after their username, such as `"andrew's Board"`, created automatically via a post-save signal in `notes/signals.py`. If a username is unavailable, the name falls back to the email prefix.
 
 All `/api/*` endpoints require:
 - Header: `Authorization: Bearer <accessToken>`

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -88,7 +88,7 @@ class RegistrationTests(APITestCase):
         )
 
         user = User.objects.get(username="test_email")
-        board = Board.objects.filter(owner=user, name="test_email's board").first()
+        board = Board.objects.filter(owner=user, name="test_email's Board").first()
         self.assertIsNotNone(
             board,
             "Default board was not created for the user.",
@@ -151,7 +151,7 @@ class RegistrationTests(APITestCase):
         board = Board.objects.filter(owner=user).first()
 
         self.assertIsNotNone(board, "Default board was not created.")
-        self.assertEqual(board.name, "fallback's board")
+        self.assertEqual(board.name, "fallback's Board")
 
     def test_register_missing_email(self):
         response = self.client.post(

--- a/backend/notes/signals.py
+++ b/backend/notes/signals.py
@@ -19,7 +19,7 @@ def create_default_board(sender, instance, created, **kwargs):
     fallback = (instance.email or "").split("@", 1)[0].strip()
     base_name = username or fallback or "My"
     Board.objects.create(
-        name=f"{base_name}'s board",
+        name=f"{base_name}'s Board",
         owner=instance,
         created_by=instance,
     )

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,39 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/notoli-mark.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
+    <meta name="theme-color" content="#1a1a1a" />
+    <meta name="description" content="Notoli is a focused, collaborative list workspace." />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/notoli-mark.svg" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>Notoli</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>Notoli requires JavaScript to run.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,9 +1,10 @@
 {
   "short_name": "Notoli",
-  "name": "Notoli - A Notion-Inspired To-Do List App",
-  "icons": [],
+  "name": "Notoli",
+  "description": "A focused, collaborative list workspace.",
+  "icons": [{ "src": "notoli-mark.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#007bff",
-  "background_color": "#ffffff"
+  "theme_color": "#1a1a1a",
+  "background_color": "#1a1a1a"
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,9 @@
   "short_name": "Notoli",
   "name": "Notoli",
   "description": "A focused, collaborative list workspace.",
-  "icons": [{ "src": "notoli-mark.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }],
+  "icons": [
+    { "src": "notoli-mark.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#1a1a1a",

--- a/frontend/public/notoli-mark.svg
+++ b/frontend/public/notoli-mark.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" fill="none">
+  <defs>
+    <linearGradient id="circle" x1="512" y1="72" x2="512" y2="952" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F6DD63"/>
+      <stop offset="1" stop-color="#F2CF45"/>
+    </linearGradient>
+    <linearGradient id="letter" x1="300" y1="260" x2="720" y2="760" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#3A210F"/>
+      <stop offset="1" stop-color="#241206"/>
+    </linearGradient>
+    <clipPath id="circleClip">
+      <circle cx="512" cy="512" r="440"/>
+    </clipPath>
+  </defs>
+
+  <circle cx="512" cy="512" r="440" fill="url(#circle)"/>
+
+  <g clip-path="url(#circleClip)" opacity="0.18" stroke="#8D6B16" stroke-width="2">
+    <line x1="96" y1="240" x2="928" y2="240"/>
+    <line x1="96" y1="288" x2="928" y2="288"/>
+    <line x1="96" y1="336" x2="928" y2="336"/>
+    <line x1="96" y1="384" x2="928" y2="384"/>
+    <line x1="96" y1="432" x2="928" y2="432"/>
+    <line x1="96" y1="480" x2="928" y2="480"/>
+    <line x1="96" y1="528" x2="928" y2="528"/>
+    <line x1="96" y1="576" x2="928" y2="576"/>
+    <line x1="96" y1="624" x2="928" y2="624"/>
+    <line x1="96" y1="672" x2="928" y2="672"/>
+    <line x1="96" y1="720" x2="928" y2="720"/>
+    <line x1="96" y1="768" x2="928" y2="768"/>
+  </g>
+
+  <path d="M290 766V258H426L653 591V258H765V766H629L402 434V766H290Z" fill="url(#letter)"/>
+</svg>

--- a/frontend/src/components/BoardNavigationDrawer.js
+++ b/frontend/src/components/BoardNavigationDrawer.js
@@ -188,15 +188,21 @@ export default function BoardNavigationDrawer({
 
   // Share Board
   const [sharingBoard, setSharingBoard] = useState(null);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
 
   const openShareDialog = (board) => {
     setSharingBoard(board);
+    setShareDialogOpen(true);
     handleTripleDotClose();
   };
 
   const updateSharedBoard = (updatedBoard) => {
     setBoards((prev) => prev.map((board) => (board.id === updatedBoard.id ? updatedBoard : board)));
     setSharingBoard(updatedBoard);
+  };
+
+  const closeShareDialog = () => {
+    setShareDialogOpen(false);
   };
 
   // Remove board
@@ -518,10 +524,11 @@ export default function BoardNavigationDrawer({
         )}
       </Menu>
       <BoardShareDialog
-        open={Boolean(sharingBoard)}
+        open={shareDialogOpen}
         board={sharingBoard}
         token={token}
-        onClose={() => setSharingBoard(null)}
+        onClose={closeShareDialog}
+        onExited={() => setSharingBoard(null)}
         onBoardUpdated={updateSharedBoard}
         showSnackbar={showSnackbar}
       />

--- a/frontend/src/components/BoardShareDialog.js
+++ b/frontend/src/components/BoardShareDialog.js
@@ -130,6 +130,7 @@ export default function BoardShareDialog({
   board,
   token,
   onClose,
+  onExited,
   onBoardUpdated,
   showSnackbar,
 }) {
@@ -217,6 +218,7 @@ export default function BoardShareDialog({
       fullWidth
       maxWidth={false}
       slotProps={{
+        transition: { onExited },
         paper: {
           sx: {
             width: 'min(480px, calc(100vw - 32px))',

--- a/frontend/src/components/PullToRefreshIndicator.js
+++ b/frontend/src/components/PullToRefreshIndicator.js
@@ -2,6 +2,8 @@ import { Box } from '@mui/material';
 import Refresh from '@mui/icons-material/Refresh';
 
 const FULL_PULL_DISTANCE = 84;
+const ACTIVE_SPIN_DURATION_MS = 1400;
+const ACTIVE_SPIN_START_DELAY_MS = -(ACTIVE_SPIN_DURATION_MS * 0.75);
 
 export default function PullToRefreshIndicator({ pullDistance, refreshReady, isRefreshing }) {
   const active = isRefreshing || pullDistance > 0;
@@ -11,7 +13,7 @@ export default function PullToRefreshIndicator({ pullDistance, refreshReady, isR
       ? 'Release to refresh'
       : 'Pull to refresh';
   const pullProgress = Math.min(pullDistance / FULL_PULL_DISTANCE, 1);
-  const pullRotation = refreshReady ? 360 : Math.round(pullProgress * 270);
+  const pullRotation = Math.round(pullProgress * 270);
 
   return (
     <Box
@@ -47,7 +49,9 @@ export default function PullToRefreshIndicator({ pullDistance, refreshReady, isR
             fontSize: 28,
             transform: isRefreshing ? undefined : `rotate(${pullRotation}deg)`,
             transition: isRefreshing ? 'none' : 'transform 80ms linear',
-            animation: isRefreshing ? 'notoliRefreshSpin 750ms linear infinite' : 'none',
+            animation: isRefreshing
+              ? `notoliRefreshSpin ${ACTIVE_SPIN_DURATION_MS}ms linear infinite ${ACTIVE_SPIN_START_DELAY_MS}ms`
+              : 'none',
           },
         }}
       >

--- a/frontend/src/components/PullToRefreshIndicator.test.js
+++ b/frontend/src/components/PullToRefreshIndicator.test.js
@@ -42,5 +42,8 @@ describe('PullToRefreshIndicator', () => {
 
     expect(screen.getByRole('status', { name: /refreshing/i })).toBeInTheDocument();
     expect(screen.getByTestId('RefreshIcon')).toBeInTheDocument();
+    expect(screen.getByTestId('RefreshIcon')).toHaveStyle(
+      'animation: notoliRefreshSpin 1400ms linear infinite -1050ms',
+    );
   });
 });

--- a/frontend/src/components/notepadPages/SortableNotepadItems.js
+++ b/frontend/src/components/notepadPages/SortableNotepadItems.js
@@ -21,6 +21,7 @@ import Divider from '@mui/material/Divider';
 
 export const NOTEPAD_ITEM_VERTICAL_GAP = '8px';
 export const NOTEPAD_ITEM_ROW_MIN_HEIGHT = 42;
+export const NOTEPAD_ITEM_FOOTPRINT_HEIGHT = 52;
 export const VERTICAL_REORDER_DRAG_MODIFIERS = [
   ({ transform }) => ({
     ...transform,
@@ -80,7 +81,26 @@ export default function SortableNotepadItems({
 
   if (!items.length) {
     return (
-      <Typography variant="body1" align="center" fontWeight="bold" sx={{ fontSize: '1.1rem' }}>
+      <Typography
+        data-testid={`${testIdPrefix}-empty-state`}
+        variant="body1"
+        align="center"
+        fontWeight="bold"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          // Match one rendered list item: 42px row + 8px list gap + 2px divider.
+          minHeight: NOTEPAD_ITEM_FOOTPRINT_HEIGHT,
+          boxSizing: 'border-box',
+          px: 2,
+          borderRadius: 1,
+          borderBottom: '2px solid var(--secondary-color)',
+          bgcolor: 'var(--secondary-background-color)',
+          color: 'var(--secondary-color)',
+          fontSize: '1.1rem',
+        }}
+      >
         {emptyMessage}
       </Typography>
     );

--- a/frontend/src/components/notepadPages/SortableNotepadItems.test.js
+++ b/frontend/src/components/notepadPages/SortableNotepadItems.test.js
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import SortableNotepadItems, {
   DRAG_HANDLE_TOUCH_STYLE,
   NOTEPAD_ITEM_ROW_MIN_HEIGHT,
+  NOTEPAD_ITEM_FOOTPRINT_HEIGHT,
   NOTEPAD_ITEM_VERTICAL_GAP,
 } from './SortableNotepadItems';
 import { renderWithProviders } from '../../test-support/utils';
@@ -26,6 +27,10 @@ describe('SortableNotepadItems', () => {
     );
 
     expect(screen.getByText('No rows found.')).toBeInTheDocument();
+    expect(screen.getByTestId('row-empty-state')).toHaveStyle({
+      minHeight: '52px',
+      borderBottom: '2px solid var(--secondary-color)',
+    });
   });
 
   test('when not reordering, it renders the rows in a stable vertical list', () => {
@@ -70,5 +75,6 @@ describe('SortableNotepadItems', () => {
     expect(screen.getByTestId('row-sortable-row-1')).toBeInTheDocument();
     expect(screen.getByTestId('drag-1').style.touchAction).toBe('none');
     expect(NOTEPAD_ITEM_ROW_MIN_HEIGHT).toBe(42);
+    expect(NOTEPAD_ITEM_FOOTPRINT_HEIGHT).toBe(52);
   });
 });

--- a/frontend/src/pages/boards/BoardListsPage.js
+++ b/frontend/src/pages/boards/BoardListsPage.js
@@ -1,5 +1,5 @@
 // BoardListsPage loads one board's lists and plugs board-specific CRUD/navigation into notepad UI.
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { Box, Button, IconButton, Typography } from '@mui/material';
 import Add from '@mui/icons-material/Add';
@@ -63,9 +63,13 @@ export default function BoardListsPage({ setAppBarHeader }) {
   const [editListName, setEditListName] = useState('');
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setAppBarHeader('');
   }, [setAppBarHeader]);
+
+  useEffect(() => {
+    document.title = boardName ? `Notoli - ${boardName}` : 'Notoli';
+  }, [boardName]);
 
   const fetchLists = useCallback(async () => {
     setLoading(true);
@@ -264,7 +268,11 @@ export default function BoardListsPage({ setAppBarHeader }) {
             color: 'var(--secondary-color)',
             textTransform: 'none',
           }}
-          onClick={() => navigate(`/board/${boardId}/list/${list.id}`)}
+          onClick={() =>
+            navigate(`/board/${boardId}/list/${list.id}`, {
+              state: { boardName, listName: list.name },
+            })
+          }
         >
           <Typography variant="body1" fontWeight="bold" sx={rowTitleSx}>
             {list.name}

--- a/frontend/src/pages/boards/BoardListsPage.test.js
+++ b/frontend/src/pages/boards/BoardListsPage.test.js
@@ -335,7 +335,9 @@ describe('BoardListsPage', () => {
 
     await userEvent.click(await screen.findByText('test_list_01'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/board/1/list/10');
+    expect(mockNavigate).toHaveBeenCalledWith('/board/1/list/10', {
+      state: { boardName: 'test_board_01', listName: 'test_list_01' },
+    });
   });
 
   test('when the boardId changes, it refetches the lists', async () => {

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -1,11 +1,11 @@
 // ListTasksPage loads one list's tasks and adds task-specific completion behavior to notepad UI.
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { Box, Button, Checkbox, IconButton, Typography } from '@mui/material';
 import Add from '@mui/icons-material/Add';
 import DragIndicator from '@mui/icons-material/DragIndicator';
 import MoreVert from '@mui/icons-material/MoreVert';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import InlineTextEditor from '../../components/notepadPages/InlineTextEditor';
 import NotepadPageShell from '../../components/notepadPages/NotepadPageShell';
 import NotepadRowActionMenu from '../../components/notepadPages/NotepadRowActionMenu';
@@ -28,6 +28,8 @@ import { usePullToRefresh } from '../../hooks/useMobileGestures';
 const NOTE_STATUS_NOT_STARTED = 'Not Started';
 const NOTE_STATUS_COMPLETE = 'Complete';
 const isTaskComplete = (task) => task.status === NOTE_STATUS_COMPLETE;
+const formatDocumentTitle = (boardName, listName) =>
+  boardName && listName ? `Notoli - ${boardName} - ${listName}` : 'Notoli';
 
 const rowSx = {
   display: 'flex',
@@ -51,7 +53,9 @@ const pageActionButtonSx = {
 
 export default function ListTasksPage({ setAppBarHeader }) {
   const { boardId, listId } = useParams();
+  const location = useLocation();
   const token = sessionStorage.getItem('accessToken');
+  const [boardName, setBoardName] = useState('');
   const [listName, setListName] = useState('');
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -64,6 +68,15 @@ export default function ListTasksPage({ setAppBarHeader }) {
   const [editingTaskId, setEditingTaskId] = useState(null);
   const [editTask, setEditTask] = useState('');
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
+
+  // Preserve the AppBar's existing board-only behavior; its title is unrelated to the browser tab.
+  useLayoutEffect(() => {
+    setAppBarHeader(location.state?.boardName ?? '');
+  }, [boardId, location.state?.boardName, setAppBarHeader]);
+
+  useEffect(() => {
+    document.title = formatDocumentTitle(location.state?.boardName || boardName, location.state?.listName || listName);
+  }, [boardName, listName, location.state?.boardName, location.state?.listName]);
 
   const fetchTasks = useCallback(async () => {
     setLoading(true);
@@ -95,29 +108,37 @@ export default function ListTasksPage({ setAppBarHeader }) {
     }
   }, [listId, token]);
 
-  const fetchBoardName = useCallback(async () => {
-    setAppBarHeader('');
-
+  const fetchBoardName = useCallback(async (isActive = () => true) => {
     if (!boardId) return;
 
     try {
       const response = await fetchBoardApi(boardId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const boardData = await response.json();
-      setAppBarHeader(boardData?.name ?? '');
+      if (isActive()) {
+        setBoardName(boardData?.name ?? '');
+        setAppBarHeader(boardData?.name ?? '');
+      }
     } catch (err) {
-      setAppBarHeader('');
+      if (isActive()) {
+        setBoardName('');
+        setAppBarHeader('');
+      }
       setError(err.toString());
     }
   }, [boardId, token, setAppBarHeader]);
 
   useEffect(() => {
+    let active = true;
     if (listId) {
       rememberLastBoard(boardId);
       fetchTasks();
       fetchListName();
-      fetchBoardName();
+      fetchBoardName(() => active);
     }
+    return () => {
+      active = false;
+    };
   }, [boardId, listId, fetchTasks, fetchListName, fetchBoardName]);
 
   const closeActionMenu = () => {

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -75,7 +75,10 @@ export default function ListTasksPage({ setAppBarHeader }) {
   }, [boardId, location.state?.boardName, setAppBarHeader]);
 
   useEffect(() => {
-    document.title = formatDocumentTitle(location.state?.boardName || boardName, location.state?.listName || listName);
+    document.title = formatDocumentTitle(
+      location.state?.boardName || boardName,
+      location.state?.listName || listName,
+    );
   }, [boardName, listName, location.state?.boardName, location.state?.listName]);
 
   const fetchTasks = useCallback(async () => {
@@ -108,25 +111,28 @@ export default function ListTasksPage({ setAppBarHeader }) {
     }
   }, [listId, token]);
 
-  const fetchBoardName = useCallback(async (isActive = () => true) => {
-    if (!boardId) return;
+  const fetchBoardName = useCallback(
+    async (isActive = () => true) => {
+      if (!boardId) return;
 
-    try {
-      const response = await fetchBoardApi(boardId, token);
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const boardData = await response.json();
-      if (isActive()) {
-        setBoardName(boardData?.name ?? '');
-        setAppBarHeader(boardData?.name ?? '');
+      try {
+        const response = await fetchBoardApi(boardId, token);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const boardData = await response.json();
+        if (isActive()) {
+          setBoardName(boardData?.name ?? '');
+          setAppBarHeader(boardData?.name ?? '');
+        }
+      } catch (err) {
+        if (isActive()) {
+          setBoardName('');
+          setAppBarHeader('');
+        }
+        setError(err.toString());
       }
-    } catch (err) {
-      if (isActive()) {
-        setBoardName('');
-        setAppBarHeader('');
-      }
-      setError(err.toString());
-    }
-  }, [boardId, token, setAppBarHeader]);
+    },
+    [boardId, token, setAppBarHeader],
+  );
 
   useEffect(() => {
     let active = true;

--- a/frontend/src/pages/lists/ListTasksPage.test.js
+++ b/frontend/src/pages/lists/ListTasksPage.test.js
@@ -307,6 +307,25 @@ describe('ListTasksPage', () => {
     await waitFor(() => {
       expect(setAppBarHeader).toHaveBeenCalledWith('test_board_01');
     });
+    await waitFor(() => {
+      expect(document.title).toBe('Notoli - test_board_01 - List 5');
+    });
+  });
+
+  test('when navigation provides a board name, it sets the app bar header before the fallback request returns', async () => {
+    const deferred = createDeferred();
+    fetchBoardApi.mockReturnValueOnce(deferred.promise);
+    const setAppBarHeader = jest.fn();
+
+    renderWithProviders(<ListTasksPage setAppBarHeader={setAppBarHeader} />, {
+      routeEntries: [
+        { pathname: '/board/1/list/5', state: { boardName: 'Project board', listName: 'Inbox' } },
+      ],
+    });
+
+    expect(setAppBarHeader).toHaveBeenCalledWith('Project board');
+    expect(document.title).toBe('Notoli - Project board - Inbox');
+    await waitForLoadingToFinish();
   });
 
   test('when the list fetch fails, it shows an error and does not show the old hardcoded title', async () => {
@@ -397,12 +416,17 @@ describe('ListTasksPage', () => {
     expect(await screen.findByText('Error: Error: HTTP 500')).toBeInTheDocument();
   });
 
-  test('when the notes list is empty, it shows the empty state message', async () => {
+  test('when the last note is gone, the empty row keeps Add New at one complete note-item height', async () => {
     fetchNotesApi.mockResolvedValueOnce({ ok: true, json: async () => [] });
 
     await renderNotes();
 
     expect(await screen.findByText(/no notes found/i)).toBeInTheDocument();
+    expect(screen.getByTestId('note-empty-state')).toHaveStyle({
+      minHeight: '52px',
+      borderBottom: '2px solid var(--secondary-color)',
+    });
+    expect(screen.getByRole('button', { name: /add new/i })).toBeInTheDocument();
   });
 
   test('when a mobile user pulls down from the top, it refreshes the notes', async () => {

--- a/frontend/src/services/requestClient.js
+++ b/frontend/src/services/requestClient.js
@@ -88,12 +88,56 @@ function handleUnauthorized() {
   redirectToLogin();
 }
 
+let refreshRequest = null;
+
+async function refreshAccessToken() {
+  if (refreshRequest) return refreshRequest;
+
+  const refreshToken = sessionStorage.getItem('refreshToken');
+  if (!refreshToken) return { status: 'invalid' };
+
+  refreshRequest = (async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/auth/refresh/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh: refreshToken }),
+      });
+      if (response.status === 400 || response.status === 401) return { status: 'invalid' };
+      if (!response.ok) return { status: 'transient' };
+
+      const data = await response.json();
+      if (!data?.access) return { status: 'transient' };
+      sessionStorage.setItem('accessToken', data.access);
+      if (data.refresh) sessionStorage.setItem('refreshToken', data.refresh);
+      return { status: 'refreshed', accessToken: data.access };
+    } catch (_err) {
+      return { status: 'transient' };
+    } finally {
+      refreshRequest = null;
+    }
+  })();
+
+  return refreshRequest;
+}
+
+function withAccessToken(options, accessToken) {
+  return {
+    ...options,
+    headers: { ...(options.headers || {}), Authorization: `Bearer ${accessToken}` },
+  };
+}
+
 export async function apiFetch(path, options = {}) {
   const url = `${API_BASE_URL}${path}`;
   const response = await fetch(url, options);
 
   if (response?.status === 401 && shouldRedirectToLogin(path)) {
-    handleUnauthorized();
+    const refreshResult = await refreshAccessToken();
+    if (refreshResult.status === 'refreshed') {
+      return fetch(url, withAccessToken(options, refreshResult.accessToken));
+    }
+    if (refreshResult.status === 'invalid') handleUnauthorized();
   }
 
   return response;

--- a/frontend/src/services/requestClient.test.js
+++ b/frontend/src/services/requestClient.test.js
@@ -55,7 +55,7 @@ describe('requestClient', () => {
     expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/path', options);
   });
 
-  test('when a non-auth endpoint returns 401, it clears tokens and redirects to /login', async () => {
+  test('when a non-auth endpoint and refresh token are invalid, it clears tokens and redirects to /login', async () => {
     delete process.env.REACT_APP_API_BASE_URL;
     global.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 401 }));
 
@@ -78,6 +78,55 @@ describe('requestClient', () => {
       message: 'Your session expired. Please log in again.',
     });
     expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
+  test('when an access token expires, it refreshes once and retries without logging out', async () => {
+    delete process.env.REACT_APP_API_BASE_URL;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ access: 'NEW_ACCESS' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    sessionStorage.setItem('accessToken', 'ACCESS');
+    sessionStorage.setItem('refreshToken', 'REFRESH');
+
+    const { setNavigate } = await import('./navigationService');
+    const mockNavigate = jest.fn();
+    setNavigate(mockNavigate);
+    const { apiFetch } = await import('./requestClient');
+
+    const response = await apiFetch('/api/boards/', {
+      headers: { Authorization: 'Bearer ACCESS' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sessionStorage.getItem('accessToken')).toBe('NEW_ACCESS');
+    expect(sessionStorage.getItem('refreshToken')).toBe('REFRESH');
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenLastCalledWith('http://localhost:8000/api/boards/', {
+      headers: { Authorization: 'Bearer NEW_ACCESS' },
+    });
+  });
+
+  test('when refresh has a transient failure, it preserves the session and returns the original response', async () => {
+    delete process.env.REACT_APP_API_BASE_URL;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: false, status: 503 });
+    sessionStorage.setItem('accessToken', 'ACCESS');
+    sessionStorage.setItem('refreshToken', 'REFRESH');
+    const { setNavigate } = await import('./navigationService');
+    const mockNavigate = jest.fn();
+    setNavigate(mockNavigate);
+    const { apiFetch } = await import('./requestClient');
+
+    const response = await apiFetch('/api/boards/');
+
+    expect(response.status).toBe(401);
+    expect(sessionStorage.getItem('accessToken')).toBe('ACCESS');
+    expect(sessionStorage.getItem('refreshToken')).toBe('REFRESH');
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   test('when /auth/login/ returns 401, it does not redirect or clear tokens', async () => {

--- a/frontend/src/services/requestClient.test.js
+++ b/frontend/src/services/requestClient.test.js
@@ -85,7 +85,11 @@ describe('requestClient', () => {
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({ ok: false, status: 401 })
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ access: 'NEW_ACCESS' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ access: 'NEW_ACCESS' }),
+      })
       .mockResolvedValueOnce({ ok: true, status: 200 });
     sessionStorage.setItem('accessToken', 'ACCESS');
     sessionStorage.setItem('refreshToken', 'REFRESH');


### PR DESCRIPTION
## Summary
- Stabilize navigation, sharing, refresh-session handling, and mobile list presentation.
- Add Notoli browser branding and dynamic browser-tab titles.
- Capitalize the generated default board suffix for new users.

## Why
This combines the requested fixes for issues #47, #381, #482, #524, #530, #546, and #550, plus the final default-board naming polish.

## Validation
- `python manage.py test authentication -v 2` — 36 passed
- `python manage.py test notifications -v 1` — 21 passed
- `python manage.py test notes -v 1` — exceeded the local five-minute command ceiling without reporting a failure
- `npm test -- --watchAll=false --runInBand` — 237 passed
- `npm run lint:strict` — passed