### PR TITLE
Fix derived email default board capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Added notification board/list/note navigation context and `target_path` routing metadata for shared board activity.
 - Added completion-specific shared note notifications when a note transitions to `Complete`.
 ### Fixed
+- Capitalized default board names when registration auto-derives the username from the email prefix.
 - Updated OpenAI GitHub automation to use the Responses API with `gpt-5.6-luna` and omit unsupported temperature settings.
 - Prevented AppBar title flicker during list-to-board navigation by ignoring stale title requests.
 - Kept sharing access rows mounted through the dialog close transition.

--- a/backend/README.md
+++ b/backend/README.md
@@ -27,7 +27,7 @@ Common endpoints:
 - `POST /auth/forgot-password/` -> accepts `email`; sends a reset link if the account exists and returns a generic success message
 - `POST /auth/reset-password/` -> accepts `uid`, `token`, and `password`; sets a new password when the token is valid
 
-New users get a default board named after their username, such as `"andrew's Board"`, created automatically via a post-save signal in `notes/signals.py`. If a username is unavailable, the name falls back to the email prefix with its first letter capitalized, such as `"Jaalaba's Board"` for `jaalaba@gmail.com`. The default personal board is also bootstrapped with ordered starter lists: `Grocery List`, `Chores List`, and `Todo List`, each with starter notes.
+New users get a default board named after their username, such as `"andrew's Board"`, created automatically via a post-save signal in `notes/signals.py`. If the username is auto-derived from the email prefix, the board name uses that prefix with its first letter capitalized, such as `"Example_02's Board"` for `example_02@gmail.com`. The default personal board is also bootstrapped with ordered starter lists: `Grocery List`, `Chores List`, and `Todo List`, each with starter notes.
 
 All `/api/*` endpoints require:
 - Header: `Authorization: Bearer <accessToken>`

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -89,7 +89,7 @@ class RegistrationTests(APITestCase):
         )
 
         user = User.objects.get(username="test_email")
-        board = Board.objects.filter(owner=user, name="test_email's Board").first()
+        board = Board.objects.filter(owner=user, name="Test_email's Board").first()
         self.assertIsNotNone(
             board,
             "Default board was not created for the user.",
@@ -181,6 +181,40 @@ class RegistrationTests(APITestCase):
             "test_email",
             f"Unexpected username for default email: {created_user.username}",
         )
+
+    def test_register_default_board_capitalizes_derived_email_username(self):
+        response = self.client.post(
+            "/auth/register/",
+            {"email": "example_02@gmail.com", "password": "test_password"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        user = User.objects.get(email="example_02@gmail.com")
+        board = Board.objects.filter(owner=user).first()
+
+        self.assertIsNotNone(board, "Default board was not created.")
+        self.assertEqual(user.username, "example_02")
+        self.assertEqual(board.name, "Example_02's Board")
+
+    def test_register_default_board_preserves_explicit_username(self):
+        response = self.client.post(
+            "/auth/register/",
+            {
+                "email": "custom@example.com",
+                "username": "customUser",
+                "password": "test_password",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        user = User.objects.get(email="custom@example.com")
+        board = Board.objects.filter(owner=user).first()
+
+        self.assertIsNotNone(board, "Default board was not created.")
+        self.assertEqual(user.username, "customUser")
+        self.assertEqual(board.name, "customUser's Board")
 
     def test_default_board_name_falls_back_to_email_prefix(self):
         user = User(username="", email="jaalaba@gmail.com")

--- a/backend/notes/signals.py
+++ b/backend/notes/signals.py
@@ -48,6 +48,14 @@ def _capitalize_first(value):
     return value[0].upper() + value[1:]
 
 
+def _default_board_base_name(user):
+    username = (user.get_username() or "").strip()
+    fallback = (user.email or "").split("@", 1)[0].strip()
+    if username and username != fallback:
+        return username
+    return _capitalize_first(fallback or username) or "My"
+
+
 def seed_default_personal_board(board, user):
     for list_position, (list_name, note_texts) in enumerate(
         DEFAULT_PERSONAL_BOARD_CONTENT
@@ -80,9 +88,7 @@ def create_default_board(sender, instance, created, **kwargs):
         return
     if Board.objects.filter(owner=instance).exists():
         return
-    username = (instance.get_username() or "").strip()
-    fallback = (instance.email or "").split("@", 1)[0].strip()
-    base_name = username or _capitalize_first(fallback) or "My"
+    base_name = _default_board_base_name(instance)
     with transaction.atomic():
         board = Board.objects.create(
             name=f"{base_name}'s Board",


### PR DESCRIPTION
## 📌 Summary (what & why):
- Corrects default personal board naming for users whose username is automatically derived from their email address.
- Derived email prefixes are now capitalized in the board name while preserving explicitly supplied usernames unchanged.
- Adds documentation and regression coverage for both naming paths.

## 📂 Scope (what areas are affected):
- Backend registration and default-board creation logic.
- Authentication tests and backend setup documentation.
- Project changelog.

## 🔄 Behavior Changes (user-visible or API-visible):
- An account registered with `example_02@gmail.com` now receives `Example_02's Board` instead of `example_02's Board`.
- Accounts with an explicit username continue to receive a board named from that username, such as `customUser's Board`.
- No API contract changes are introduced; the change affects the automatically created board’s name.