### PR TITLE
Restrict Dependabot AI review to failing lint or test runs

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -27,11 +27,12 @@ What it does:
 - Runs the reusable malware gate: [`.github/workflows/malware-gate.yml`](workflows/malware-gate.yml)
   - Uses the local [npm malware review action](actions/review-npm-malware/action.yml) to compare changed `frontend/package-lock.json` packages against GitHub's npm malware advisories.
   - Updates one PR summary comment and fails when a changed package/version matches a known malware advisory.
-- For non-Dependabot PRs, runs [`.github/workflows/commentary.yml`](workflows/commentary.yml)
-  - Generates an OpenAI-written PR summary and PR review
+- For non-Dependabot PRs, and for Dependabot PRs with a failed lint or test area, runs [`.github/workflows/commentary.yml`](workflows/commentary.yml)
+  - Generates an OpenAI-written PR summary for non-Dependabot PRs
+  - Generates an AI code review for Dependabot PRs only when frontend/backend lint or tests fail, avoiding token use for healthy dependency updates
   - Posts the summary to the PR description or as a comment
   - Creates a PR review with up to 6 inline comments (when line placement is valid)
-- For Dependabot PRs, runs [`.github/workflows/auto_merge.yml`](workflows/auto_merge.yml) only when lints, tests, vulnerability review, and malware review pass.
+- For Dependabot PRs, runs [`.github/workflows/auto_merge.yml`](workflows/auto_merge.yml) only when lints, tests, vulnerability review, and malware review pass. CodeQL or security-only failures do not invoke the conditional Dependabot AI review.
 
 OpenAI inputs (commentary workflow):
 - `OPENAI_API_KEY` (optional secret)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,15 @@ jobs:
     needs: [lints, tests, codeql, dependency-vulnerability, dependency-malware]
     if: >-
       always() &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      (
+        github.event.pull_request.user.login != 'dependabot[bot]' ||
+        needs.lints.result == 'failure' ||
+        needs.tests.result == 'failure' ||
+        needs.lints.outputs.lint_frontend_status == 'failure' ||
+        needs.lints.outputs.lint_backend_status == 'failure' ||
+        needs.tests.outputs.test_frontend_status == 'failure' ||
+        needs.tests.outputs.test_backend_status == 'failure'
+      )
     uses: ./.github/workflows/commentary.yml
     secrets: inherit
     with:

--- a/.github/workflows/commentary.yml
+++ b/.github/workflows/commentary.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   ai-summary:
     name: ai-summary
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -118,7 +118,12 @@ jobs:
 
   ai-review:
     name: ai-review
-    if: github.actor != 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' ||
+      inputs.lint_frontend_status == 'failure' ||
+      inputs.lint_backend_status == 'failure' ||
+      inputs.test_frontend_status == 'failure' ||
+      inputs.test_backend_status == 'failure'
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project are documented in this file.
 
 ## 2026-07-10
+### Changed
+- Run the AI code review for Dependabot pull requests only when linting or tests fail, while continuing to skip AI calls for healthy dependency updates.
+
+## 2026-07-10
 ### Added
 - Added default personal-board starter lists and notes for newly registered users.
 ### Changed


### PR DESCRIPTION
## Summary
- Keep the OpenAI PR summary disabled for Dependabot updates.
- Allow AI code review on Dependabot PRs only when frontend or backend lint/tests fail.
- Update workflow docs to reflect the new conditional behavior and note that security-only failures do not trigger AI review.

## Testing
- Not run (not requested)