### PR TITLE
Limit Dependabot AI reviews to failed gates

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -41,7 +41,7 @@ What it does:
   - Consumes explicit gate results, vulnerability/malware reports, security check summaries, check annotations, prior RoboCop reviews on the PR, and the line-numbered PR diff before publishing one native PR review.
   - Requests changes for actionable security findings; approves clean security evidence.
   - Dependency Review, malware scanning, and CodeQL remain independent required checks; RoboCop does not replace them.
-- For Dependabot PRs, runs [`.github/workflows/ci-auto-merge.yml`](workflows/ci-auto-merge.yml) only when lints, tests, CodeQL, vulnerability review, and malware review pass. Failed lint/test evidence routes to Lint Eastwood, and failed security evidence routes to RoboCop; the general Obi-Wan Code-nobi review remains skipped for Dependabot updates.
+- For Dependabot PRs, runs AI reviews only when a gate fails: failed lint/test evidence routes to Lint Eastwood, failed CodeQL/vulnerability/malware evidence routes to RoboCop, and Obi-Wan Code-nobi never runs. When all gates pass, no AI review is requested and [`.github/workflows/ci-auto-merge.yml`](workflows/ci-auto-merge.yml) can run.
 
 OpenAI and GitHub App inputs:
 - `OPENAI_API_KEY` secret. Triggered AI reviews fail visibly when the key is missing.
@@ -131,6 +131,7 @@ Dependabot configuration:
 
 Auto-merge behavior:
 - Dependabot PRs go through CI (`ci-orchestrator.yml`), and if all gates pass, `ci-auto-merge.yml` can enable auto-merge.
+- Passing Dependabot PRs do not receive AI reviews. Lint Eastwood runs only when lint or test gates fail; RoboCop runs only when CodeQL, vulnerability, or malware gates fail; Obi-Wan Code-nobi is always skipped for Dependabot.
 - Auto-merge is restricted to patch/minor updates.
 - If a security alert is present, the workflow requires CVSS <= 6.9.
 - The workflow uses `dependabot/fetch-metadata@v2` and can optionally use `DEPENDABOT_PAT` for metadata/alert lookup.

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -59,7 +59,14 @@ jobs:
   build-review:
     name: AI Build Sheriff Review
     needs: [lints, tests]
-    if: always() && github.event_name == 'pull_request'
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      (
+        github.event.pull_request.user.login != 'dependabot[bot]' ||
+        needs.lints.result != 'success' ||
+        needs.tests.result != 'success'
+      )
     uses: ./.github/workflows/review-build.yml
     secrets: inherit
     permissions:
@@ -80,7 +87,15 @@ jobs:
   security-review:
     name: AI Security Review
     needs: [codeql, dependency-vulnerability, dependency-malware]
-    if: always() && github.event_name == 'pull_request'
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      (
+        github.event.pull_request.user.login != 'dependabot[bot]' ||
+        needs.codeql.result != 'success' ||
+        needs.dependency-vulnerability.result != 'success' ||
+        needs.dependency-malware.result != 'success'
+      )
     uses: ./.github/workflows/review-security.yml
     secrets: inherit
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
 ### Changed
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.
+- Dependabot pull requests now request AI reviews only on failed gates: Lint Eastwood for lint/test failures and RoboCop for CodeQL, vulnerability, or malware failures, while Obi-Wan Code-nobi remains skipped.
 - Automated frontend and backend lint-fix commits now use the `Lint Eastwood <41898282+github-actions[bot]@users.noreply.github.com>` author and committer identity.
 
 ## 2026-07-11


### PR DESCRIPTION
## Summary
- Run Lint Eastwood for Dependabot PRs only when lint or test gates fail.
- Run RoboCop for Dependabot PRs only when CodeQL, vulnerability, or malware gates fail.
- Keep Obi-Wan Code-nobi skipped for all Dependabot PRs.
- Document that clean Dependabot PRs receive no AI review and proceed to auto-merge eligibility.

## Validation
- Parsed `.github/workflows/ci-orchestrator.yml` with Python/PyYAML.
- Ran `git diff --check HEAD~1..HEAD`.