### PR TITLE
Add AI review section dividers

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -51,7 +51,7 @@ OpenAI and GitHub App inputs:
 - `ROBOCOP_APP_ID` repository variable and `ROBOCOP_PRIVATE_KEY` repository secret authenticate the RoboCop GitHub App. Install it with `Contents: read`, `Pull requests: write`, `Checks: read`, `Actions: read`, and `Security events: read`.
 - AI reviews use `gpt-5.6-luna` through the local OpenAI Responses API action.
 - AI personas do not post standalone PR comments. Any bot comments are submitted as part of their native PR review.
-- AI personas read prior native reviews authored by their own GitHub App identity, suppress duplicate inline findings when the evidence has not changed, and use concise review bodies with clear section line breaks plus restrained section-heading emojis. Persona voice is prompt-guided only: RoboCop uses procedural security-officer phrasing, Lint Eastwood uses clipped build-sheriff phrasing, and Obi-Wan Code-nobi uses calm senior-reviewer phrasing.
+- AI personas read prior native reviews authored by their own GitHub App identity, suppress duplicate inline findings when the evidence has not changed, and use concise review bodies with clear section line breaks, Markdown horizontal-rule dividers, and restrained section-heading emojis. Persona voice is prompt-guided only: RoboCop uses procedural security-officer phrasing, Lint Eastwood uses clipped build-sheriff phrasing, and Obi-Wan Code-nobi uses calm senior-reviewer phrasing.
 
 Review personas:
 - **RoboCop - AI Security Officer:** owns CodeQL, Dependency/Vulnerability Review, Malware Review, security-sensitive code paths, permissions/auth risk, and security interpretation.

--- a/.github/workflows/review-build.yml
+++ b/.github/workflows/review-build.yml
@@ -155,10 +155,14 @@ jobs:
             - Add inline comments only when each comment is useful and tied to a valid added line. If no valid line applies, put the finding in the body.
             - Clearly distinguish direct check output from your interpretation.
             - Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
+            - Add a Markdown horizontal rule line (`---`) between each major section to create a visible divider. Do not put a divider before the first heading or after the final section.
             - Use this section shape:
               - "### 🤠 Lint Eastwood verdict" with the decision and one firm, dry summary sentence.
+              - "---"
               - "### 🧾 Check evidence" with bullets for lint/test/build statuses and relevant log facts.
+              - "---"
               - "### 🔧 Findings" with bullets for new actionable findings, or "No new findings." when clear.
+              - "---"
               - "### ✅ Next steps" only when there is a concrete author action.
             - Do not put emojis inside inline review comments.
 

--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -179,10 +179,14 @@ jobs:
             - If a finding comes from repository context, changed-file contents, a deleted line, an unchanged line, or any line not shown as "A<line>:", put the finding in the body and do not add an inline comment for it.
             - If the diff is truncated, mention it in the body.
             - Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
+            - Add a Markdown horizontal rule line (`---`) between each major section to create a visible divider. Do not put a divider before the first heading or after the final section.
             - Use this section shape:
               - "### 🧭 Obi-Wan Code-nobi verdict" with the decision and one measured, slightly mentor-like summary sentence.
+              - "---"
               - "### 🔎 Findings" with bullets for new findings, or "No new findings." when clear.
+              - "---"
               - "### 📚 Evidence checked" with short bullets naming the diff/context reviewed and any prior-review history used.
+              - "---"
               - "### ✅ Next steps" only when there is a concrete action for the author.
             - Do not put emojis inside inline review comments.
 

--- a/.github/workflows/review-security.yml
+++ b/.github/workflows/review-security.yml
@@ -220,10 +220,14 @@ jobs:
 
             Use only added RIGHT-side lines from the supplied diff for inline comments. Add inline comments only when each comment is useful and evidence-backed. If context is missing, say so in the body.
             Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
+            Add a Markdown horizontal rule line (`---`) between each major section to create a visible divider. Do not put a divider before the first heading or after the final section.
             Use this section shape:
             - "### 🛡️ RoboCop verdict" with the decision and one procedural summary sentence.
+            - "---"
             - "### 📋 Tool evidence" with bullets for CodeQL, Dependency Review, Malware Review, and relevant check annotations.
+            - "---"
             - "### ⚖️ AI security conclusion" with bullets for security interpretation, or "No new security findings." when clear.
+            - "---"
             - "### ✅ Next steps" only when there is a concrete author action or evidence gap.
             Do not put emojis inside inline review comments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
 ### Changed
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.
+- AI review body prompts now request Markdown horizontal-rule dividers between major sections.
 - Dependabot pull requests now request AI reviews only on failed gates: Lint Eastwood for lint/test failures and RoboCop for CodeQL, vulnerability, or malware failures, while Obi-Wan Code-nobi remains skipped.
 - Automated frontend and backend lint-fix commits now use the `Lint Eastwood <41898282+github-actions[bot]@users.noreply.github.com>` author and committer identity.
 


### PR DESCRIPTION
## Summary
- Ask all AI reviewer personas to place Markdown horizontal rules (`---`) between major review body sections.
- Keep existing emoji headings, line-break spacing, and persona-specific review body structure.
- Document the horizontal-rule divider behavior in workflow docs and changelog.

## Validation
- Parsed changed review workflow YAML with Python/PyYAML.
- Ran `git diff --check`.