### PR TITLE
Use larger AI review section headers

### DIFF
--- a/.github/workflows/review-build.yml
+++ b/.github/workflows/review-build.yml
@@ -156,10 +156,10 @@ jobs:
             - Clearly distinguish direct check output from your interpretation.
             - Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
             - Use this section shape:
-              - "### 🤠 Lint Eastwood verdict" with the decision and one firm, dry summary sentence.
-              - "### 🧾 Check evidence" with bullets for lint/test/build statuses and relevant log facts.
-              - "### 🔧 Findings" with bullets for new actionable findings, or "No new findings." when clear.
-              - "### ✅ Next steps" only when there is a concrete author action.
+              - "## 🤠 Lint Eastwood verdict" with the decision and one firm, dry summary sentence.
+              - "## 🧾 Check evidence" with bullets for lint/test/build statuses and relevant log facts.
+              - "## 🔧 Findings" with bullets for new actionable findings, or "No new findings." when clear.
+              - "## ✅ Next steps" only when there is a concrete author action.
             - Do not put emojis inside inline review comments.
 
             Build evidence follows:

--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -180,10 +180,10 @@ jobs:
             - If the diff is truncated, mention it in the body.
             - Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
             - Use this section shape:
-              - "### 🧭 Obi-Wan Code-nobi verdict" with the decision and one measured, slightly mentor-like summary sentence.
-              - "### 🔎 Findings" with bullets for new findings, or "No new findings." when clear.
-              - "### 📚 Evidence checked" with short bullets naming the diff/context reviewed and any prior-review history used.
-              - "### ✅ Next steps" only when there is a concrete action for the author.
+              - "## 🧭 Obi-Wan Code-nobi verdict" with the decision and one measured, slightly mentor-like summary sentence.
+              - "## 🔎 Findings" with bullets for new findings, or "No new findings." when clear.
+              - "## 📚 Evidence checked" with short bullets naming the diff/context reviewed and any prior-review history used.
+              - "## ✅ Next steps" only when there is a concrete action for the author.
             - Do not put emojis inside inline review comments.
 
             Review context follows:

--- a/.github/workflows/review-security.yml
+++ b/.github/workflows/review-security.yml
@@ -221,10 +221,10 @@ jobs:
             Use only added RIGHT-side lines from the supplied diff for inline comments. Add inline comments only when each comment is useful and evidence-backed. If context is missing, say so in the body.
             Format the body in concise GitHub Markdown with clear line breaks: put one blank line after each heading and one blank line between sections. Use one restrained emoji per section heading.
             Use this section shape:
-            - "### 🛡️ RoboCop verdict" with the decision and one procedural summary sentence.
-            - "### 📋 Tool evidence" with bullets for CodeQL, Dependency Review, Malware Review, and relevant check annotations.
-            - "### ⚖️ AI security conclusion" with bullets for security interpretation, or "No new security findings." when clear.
-            - "### ✅ Next steps" only when there is a concrete author action or evidence gap.
+            - "## 🛡️ RoboCop verdict" with the decision and one procedural summary sentence.
+            - "## 📋 Tool evidence" with bullets for CodeQL, Dependency Review, Malware Review, and relevant check annotations.
+            - "## ⚖️ AI security conclusion" with bullets for security interpretation, or "No new security findings." when clear.
+            - "## ✅ Next steps" only when there is a concrete author action or evidence gap.
             Do not put emojis inside inline review comments.
 
             Security evidence follows:


### PR DESCRIPTION
## Summary
- update the AI review workflow prompts so generated review section headers use `##` instead of `###`
- keep the previous review structure intact and only make the headings render as stronger visual breaks

## Testing
- Not run; workflow prompt-only change.