### PR TITLE
Replace loading text with skeleton states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
 ### Changed
+- Replaced abrupt notepad page loading text with layout-matched skeleton placeholders.
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.
 - Dependabot pull requests now request AI reviews only on failed gates: Lint Eastwood for lint/test failures and RoboCop for CodeQL, vulnerability, or malware failures, while Obi-Wan Code-nobi remains skipped.
 - Automated frontend and backend lint-fix commits now use the `Lint Eastwood <41898282+github-actions[bot]@users.noreply.github.com>` author and committer identity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 ## 2026-07-12
 ### Added
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
+### Fixed
+- Prevented notepad page rows from shifting when board or list titles finish loading after content.
 ### Changed
 - Replaced abrupt notepad page loading text with layout-matched skeleton placeholders.
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -6,8 +6,7 @@ import PullToRefreshIndicator from '../PullToRefreshIndicator';
 const skeletonWaveSx = {
   bgcolor: 'rgba(85, 85, 85, 0.18)',
   '&::after': {
-    background:
-      'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent)',
+    background: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent)',
   },
   '@media (prefers-reduced-motion: reduce)': {
     animation: 'none',

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -138,14 +138,32 @@ export default function NotepadPageShell({
             sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 1.5 }}
           >
             <Box sx={{ width: 40 }} />
-            <Typography
-              variant="h4"
-              align="center"
-              gutterBottom
-              sx={{ fontWeight: 'bold', color: 'var(--secondary-color)' }}
-            >
-              {title}
-            </Typography>
+            {showLoading ? (
+              <Skeleton
+                variant="rounded"
+                animation="wave"
+                width="42%"
+                height={40}
+                data-testid="notepad-title-skeleton"
+                aria-hidden="true"
+                sx={{
+                  ...skeletonWaveSx,
+                  borderRadius: 1,
+                  mb: 0.35,
+                  maxWidth: 240,
+                  minWidth: 132,
+                }}
+              />
+            ) : (
+              <Typography
+                variant="h4"
+                align="center"
+                gutterBottom
+                sx={{ fontWeight: 'bold', color: 'var(--secondary-color)' }}
+              >
+                {title}
+              </Typography>
+            )}
             <Box sx={{ width: 40 }} />
           </Box>
 

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -96,6 +96,7 @@ function NotepadLoadingSkeleton() {
 
 export default function NotepadPageShell({
   title,
+  titleLoading = false,
   loading,
   error,
   hasContent = false,
@@ -106,6 +107,7 @@ export default function NotepadPageShell({
   children,
 }) {
   const showLoading = loading && !hasContent;
+  const showTitleSkeleton = showLoading || (titleLoading && !title);
   const showContent = hasContent || (!loading && !error);
 
   return (
@@ -138,7 +140,7 @@ export default function NotepadPageShell({
             sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 1.5 }}
           >
             <Box sx={{ width: 40 }} />
-            {showLoading ? (
+            {showTitleSkeleton ? (
               <Skeleton
                 variant="rounded"
                 animation="wave"

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -142,16 +142,18 @@ export default function NotepadPageShell({
               <Skeleton
                 variant="rounded"
                 animation="wave"
-                width="42%"
-                height={40}
+                width="62%"
+                height={44}
                 data-testid="notepad-title-skeleton"
                 aria-hidden="true"
                 sx={{
                   ...skeletonWaveSx,
                   borderRadius: 1,
-                  mb: 0.35,
-                  maxWidth: 240,
-                  minWidth: 132,
+                  alignSelf: 'flex-start',
+                  mt: 0.25,
+                  mb: 0.85,
+                  maxWidth: 320,
+                  minWidth: 196,
                 }}
               />
             ) : (

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -1,7 +1,99 @@
 // Shared notepad page frame for title, pull-to-refresh offset, loading/error states, and row content.
-import { Box, Container, Paper, Stack, Typography } from '@mui/material';
+import { Box, Container, Paper, Skeleton, Stack, Typography } from '@mui/material';
 import Divider from '@mui/material/Divider';
 import PullToRefreshIndicator from '../PullToRefreshIndicator';
+
+const skeletonWaveSx = {
+  bgcolor: 'rgba(85, 85, 85, 0.18)',
+  '&::after': {
+    background:
+      'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent)',
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+    '&::after': { animation: 'none' },
+  },
+};
+
+function NotepadLoadingSkeleton() {
+  const rowWidths = ['78%', '64%', '72%'];
+
+  return (
+    <Stack
+      spacing={1}
+      role="status"
+      aria-label="Loading content"
+      data-testid="notepad-loading-skeleton"
+    >
+      {rowWidths.map((width) => (
+        <Box
+          key={width}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            minHeight: 52,
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            bgcolor: 'var(--secondary-background-color)',
+            borderBottom: '2px solid rgba(85, 85, 85, 0.42)',
+            boxSizing: 'border-box',
+          }}
+        >
+          <Skeleton
+            variant="circular"
+            animation="wave"
+            width={24}
+            height={24}
+            sx={{ ...skeletonWaveSx, mr: 1.5, flex: '0 0 auto' }}
+          />
+          <Skeleton
+            variant="rounded"
+            animation="wave"
+            width={width}
+            height={22}
+            sx={{ ...skeletonWaveSx, borderRadius: 1 }}
+          />
+          <Skeleton
+            variant="circular"
+            animation="wave"
+            width={24}
+            height={24}
+            sx={{ ...skeletonWaveSx, ml: 'auto', flex: '0 0 auto' }}
+          />
+        </Box>
+      ))}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          minHeight: 52,
+          px: 1,
+          py: 0.5,
+          borderRadius: 1,
+          bgcolor: 'var(--secondary-background-color)',
+          boxSizing: 'border-box',
+        }}
+        aria-hidden="true"
+      >
+        <Skeleton
+          variant="circular"
+          animation="wave"
+          width={24}
+          height={24}
+          sx={{ ...skeletonWaveSx, mr: 1.5, flex: '0 0 auto' }}
+        />
+        <Skeleton
+          variant="rounded"
+          animation="wave"
+          width="34%"
+          height={22}
+          sx={{ ...skeletonWaveSx, borderRadius: 1 }}
+        />
+      </Box>
+    </Stack>
+  );
+}
 
 export default function NotepadPageShell({
   title,
@@ -58,8 +150,6 @@ export default function NotepadPageShell({
             <Box sx={{ width: 40 }} />
           </Box>
 
-          {showLoading && <Typography align="center"> Loading... </Typography>}
-
           {error && (
             <Typography color="error" align="center">
               Error: {error}
@@ -69,6 +159,7 @@ export default function NotepadPageShell({
           <Divider
             sx={{ borderBottomWidth: 2, marginBottom: 1, bgcolor: 'var(--secondary-color)' }}
           />
+          {showLoading && <NotepadLoadingSkeleton />}
           {showContent && <Stack spacing={1}>{children}</Stack>}
         </Box>
       </Paper>

--- a/frontend/src/components/notepadPages/NotepadPageShell.test.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.test.js
@@ -28,17 +28,21 @@ describe('NotepadPageShell', () => {
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 
-  test('when loading, it shows skeleton rows and hides child content', () => {
+  test('when loading, it shows title and row skeletons and hides child content', () => {
     renderShell({ loading: true });
 
+    expect(screen.getByTestId('notepad-title-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Board' })).not.toBeInTheDocument();
     expect(screen.getByRole('status', { name: /loading content/i })).toBeInTheDocument();
     expect(screen.getByTestId('notepad-loading-skeleton')).toBeInTheDocument();
     expect(screen.queryByText('Rows go here')).not.toBeInTheDocument();
   });
 
-  test('when refreshing existing content, it keeps child content visible', () => {
+  test('when refreshing existing content, it keeps the title and child content visible', () => {
     renderShell({ loading: true, hasContent: true });
 
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Board' })).toBeInTheDocument();
     expect(screen.queryByRole('status', { name: /loading content/i })).not.toBeInTheDocument();
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });

--- a/frontend/src/components/notepadPages/NotepadPageShell.test.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.test.js
@@ -47,6 +47,14 @@ describe('NotepadPageShell', () => {
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 
+  test('when the title is still loading but content is ready, it preserves title space', () => {
+    renderShell({ title: '', titleLoading: true, hasContent: true });
+
+    expect(screen.getByTestId('notepad-title-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: /loading content/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Rows go here')).toBeInTheDocument();
+  });
+
   test('when an error exists, it shows the error and hides child content', () => {
     renderShell({ error: 'Error: HTTP 500' });
 

--- a/frontend/src/components/notepadPages/NotepadPageShell.test.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.test.js
@@ -28,17 +28,18 @@ describe('NotepadPageShell', () => {
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 
-  test('when loading, it shows loading and hides child content', () => {
+  test('when loading, it shows skeleton rows and hides child content', () => {
     renderShell({ loading: true });
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /loading content/i })).toBeInTheDocument();
+    expect(screen.getByTestId('notepad-loading-skeleton')).toBeInTheDocument();
     expect(screen.queryByText('Rows go here')).not.toBeInTheDocument();
   });
 
   test('when refreshing existing content, it keeps child content visible', () => {
     renderShell({ loading: true, hasContent: true });
 
-    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: /loading content/i })).not.toBeInTheDocument();
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/notepadPages/NotepadPageShell.test.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.test.js
@@ -55,6 +55,14 @@ describe('NotepadPageShell', () => {
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 
+  test('when a previous title exists and the next title is loading, it keeps the title visible', () => {
+    renderShell({ title: 'Board', titleLoading: true, hasContent: true });
+
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Board' })).toBeInTheDocument();
+    expect(screen.getByText('Rows go here')).toBeInTheDocument();
+  });
+
   test('when an error exists, it shows the error and hides child content', () => {
     renderShell({ error: 'Error: HTTP 500' });
 

--- a/frontend/src/pages/boards/BoardListsPage.js
+++ b/frontend/src/pages/boards/BoardListsPage.js
@@ -88,10 +88,10 @@ export default function BoardListsPage({ setAppBarHeader }) {
   }, [token, boardId]);
 
   const fetchBoardName = useCallback(async () => {
-    setBoardName('');
     setBoardNameLoading(true);
 
     if (!boardId) {
+      setBoardName('');
       setBoardNameLoading(false);
       return;
     }
@@ -102,7 +102,6 @@ export default function BoardListsPage({ setAppBarHeader }) {
       const data = await response.json();
       setBoardName(data?.name ?? '');
     } catch (err) {
-      setBoardName('');
       setError(err.toString());
     } finally {
       setBoardNameLoading(false);

--- a/frontend/src/pages/boards/BoardListsPage.js
+++ b/frontend/src/pages/boards/BoardListsPage.js
@@ -51,6 +51,7 @@ export default function BoardListsPage({ setAppBarHeader }) {
   const { boardId } = useParams();
   const token = sessionStorage.getItem('accessToken');
   const [boardName, setBoardName] = useState('');
+  const [boardNameLoading, setBoardNameLoading] = useState(true);
   const [lists, setLists] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -88,8 +89,12 @@ export default function BoardListsPage({ setAppBarHeader }) {
 
   const fetchBoardName = useCallback(async () => {
     setBoardName('');
+    setBoardNameLoading(true);
 
-    if (!boardId) return;
+    if (!boardId) {
+      setBoardNameLoading(false);
+      return;
+    }
 
     try {
       const response = await fetchBoardApi(boardId, token);
@@ -99,6 +104,8 @@ export default function BoardListsPage({ setAppBarHeader }) {
     } catch (err) {
       setBoardName('');
       setError(err.toString());
+    } finally {
+      setBoardNameLoading(false);
     }
   }, [token, boardId]);
 
@@ -294,6 +301,7 @@ export default function BoardListsPage({ setAppBarHeader }) {
     <>
       <NotepadPageShell
         title={isReordering ? 'Reorder Lists' : boardName}
+        titleLoading={!isReordering && boardNameLoading}
         loading={loading}
         error={error}
         hasContent={lists.length > 0}

--- a/frontend/src/pages/boards/BoardListsPage.js
+++ b/frontend/src/pages/boards/BoardListsPage.js
@@ -1,5 +1,5 @@
 // BoardListsPage loads one board's lists and plugs board-specific CRUD/navigation into notepad UI.
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { Box, Button, IconButton, Typography } from '@mui/material';
 import Add from '@mui/icons-material/Add';
@@ -63,6 +63,7 @@ export default function BoardListsPage({ setAppBarHeader }) {
   const [editingListId, setEditingListId] = useState(null);
   const [editListName, setEditListName] = useState('');
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
+  const boardNameRequestIdRef = useRef(0);
 
   useLayoutEffect(() => {
     setAppBarHeader('');
@@ -88,6 +89,8 @@ export default function BoardListsPage({ setAppBarHeader }) {
   }, [token, boardId]);
 
   const fetchBoardName = useCallback(async () => {
+    const requestId = boardNameRequestIdRef.current + 1;
+    boardNameRequestIdRef.current = requestId;
     setBoardNameLoading(true);
 
     if (!boardId) {
@@ -100,10 +103,13 @@ export default function BoardListsPage({ setAppBarHeader }) {
       const response = await fetchBoardApi(boardId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
+      if (requestId !== boardNameRequestIdRef.current) return;
       setBoardName(data?.name ?? '');
     } catch (err) {
+      if (requestId !== boardNameRequestIdRef.current) return;
       setError(err.toString());
     } finally {
+      if (requestId !== boardNameRequestIdRef.current) return;
       setBoardNameLoading(false);
     }
   }, [token, boardId]);

--- a/frontend/src/pages/boards/BoardListsPage.test.js
+++ b/frontend/src/pages/boards/BoardListsPage.test.js
@@ -96,6 +96,24 @@ describe('BoardListsPage', () => {
     expect(screen.getByText('test_list_02')).toBeInTheDocument();
   });
 
+  test('when lists load before the board title, it keeps the title skeleton until the title is ready', async () => {
+    const deferredBoard = createDeferred();
+    fetchBoardApi.mockReturnValueOnce(deferredBoard.promise);
+
+    renderWithProviders(<BoardListsPage setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText('test_list_01')).toBeInTheDocument();
+    expect(screen.getByText('test_list_02')).toBeInTheDocument();
+    expect(screen.getByTestId('notepad-title-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'test_board_01' })).not.toBeInTheDocument();
+
+    deferredBoard.resolve({ ok: true, json: async () => boardFixtures[0] });
+
+    expect(await screen.findByRole('heading', { name: 'test_board_01' })).toBeInTheDocument();
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByText('test_list_01')).toBeInTheDocument();
+  });
+
   test('when the fetch fails, it shows an error message', async () => {
     fetchListsApi.mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
 

--- a/frontend/src/pages/boards/BoardListsPage.test.js
+++ b/frontend/src/pages/boards/BoardListsPage.test.js
@@ -114,6 +114,29 @@ describe('BoardListsPage', () => {
     expect(screen.getByText('test_list_01')).toBeInTheDocument();
   });
 
+  test('when a later board title is pending, it keeps the previous title instead of showing a skeleton', async () => {
+    const { rerender } = await renderLists();
+    expect(await screen.findByRole('heading', { name: 'test_board_01' })).toBeInTheDocument();
+
+    mockUseParams.mockReturnValue({ boardId: '2' });
+    fetchListsApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 12, name: 'test_list_03' }],
+    });
+    const deferredBoard = createDeferred();
+    fetchBoardApi.mockReturnValueOnce(deferredBoard.promise);
+
+    rerender(<BoardListsPage setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText('test_list_03')).toBeInTheDocument();
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'test_board_01' })).toBeInTheDocument();
+
+    deferredBoard.resolve({ ok: true, json: async () => boardFixtures[1] });
+
+    expect(await screen.findByRole('heading', { name: 'test_board_02' })).toBeInTheDocument();
+  });
+
   test('when the fetch fails, it shows an error message', async () => {
     fetchListsApi.mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
 

--- a/frontend/src/pages/boards/BoardListsPage.test.js
+++ b/frontend/src/pages/boards/BoardListsPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import BoardListsPage from './BoardListsPage';
@@ -135,6 +135,46 @@ describe('BoardListsPage', () => {
     deferredBoard.resolve({ ok: true, json: async () => boardFixtures[1] });
 
     expect(await screen.findByRole('heading', { name: 'test_board_02' })).toBeInTheDocument();
+  });
+
+  test('when board title responses resolve out of order, it ignores stale titles', async () => {
+    const { rerender } = await renderLists();
+
+    mockUseParams.mockReturnValue({ boardId: '2' });
+    fetchListsApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 12, name: 'test_list_03' }],
+    });
+    const staleBoard = createDeferred();
+    fetchBoardApi.mockReturnValueOnce(staleBoard.promise);
+
+    rerender(<BoardListsPage setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText('test_list_03')).toBeInTheDocument();
+
+    mockUseParams.mockReturnValue({ boardId: '3' });
+    fetchListsApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 13, name: 'test_list_04' }],
+    });
+    const currentBoard = createDeferred();
+    fetchBoardApi.mockReturnValueOnce(currentBoard.promise);
+
+    rerender(<BoardListsPage setAppBarHeader={jest.fn()} />);
+
+    expect(await screen.findByText('test_list_04')).toBeInTheDocument();
+
+    await act(async () => {
+      currentBoard.resolve({ ok: true, json: async () => ({ id: 3, name: 'test_board_03' }) });
+    });
+    expect(await screen.findByRole('heading', { name: 'test_board_03' })).toBeInTheDocument();
+
+    await act(async () => {
+      staleBoard.resolve({ ok: true, json: async () => boardFixtures[1] });
+    });
+
+    expect(screen.getByRole('heading', { name: 'test_board_03' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'test_board_02' })).not.toBeInTheDocument();
   });
 
   test('when the fetch fails, it shows an error message', async () => {

--- a/frontend/src/pages/boards/BoardListsPage.test.js
+++ b/frontend/src/pages/boards/BoardListsPage.test.js
@@ -68,13 +68,14 @@ describe('BoardListsPage', () => {
     });
   });
 
-  test('when the page loads, it shows a loading state', async () => {
+  test('when the page loads, it shows skeleton placeholders', async () => {
     const deferred = createDeferred();
     fetchListsApi.mockReturnValueOnce(deferred.promise);
 
     renderWithProviders(<BoardListsPage setAppBarHeader={jest.fn()} />);
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /loading content/i })).toBeInTheDocument();
+    expect(screen.getByTestId('notepad-loading-skeleton')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /lists/i })).not.toBeInTheDocument();
 
     deferred.resolve({ ok: true, json: async () => [] });

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -57,6 +57,7 @@ export default function ListTasksPage({ setAppBarHeader }) {
   const token = sessionStorage.getItem('accessToken');
   const [boardName, setBoardName] = useState('');
   const [listName, setListName] = useState('');
+  const [listNameLoading, setListNameLoading] = useState(true);
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -68,6 +69,7 @@ export default function ListTasksPage({ setAppBarHeader }) {
   const [editingTaskId, setEditingTaskId] = useState(null);
   const [editTask, setEditTask] = useState('');
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
+  const displayedListName = location.state?.listName || listName;
 
   // Preserve the AppBar's existing board-only behavior; its title is unrelated to the browser tab.
   useLayoutEffect(() => {
@@ -98,8 +100,12 @@ export default function ListTasksPage({ setAppBarHeader }) {
 
   const fetchListName = useCallback(async () => {
     setListName('');
+    setListNameLoading(true);
 
-    if (!listId) return;
+    if (!listId) {
+      setListNameLoading(false);
+      return;
+    }
     try {
       const response = await fetchListApi(listId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -108,6 +114,8 @@ export default function ListTasksPage({ setAppBarHeader }) {
     } catch (err) {
       setListName('');
       setError(err.toString());
+    } finally {
+      setListNameLoading(false);
     }
   }, [listId, token]);
 
@@ -363,7 +371,8 @@ export default function ListTasksPage({ setAppBarHeader }) {
   return (
     <>
       <NotepadPageShell
-        title={isReordering ? 'Reorder Notes' : listName}
+        title={isReordering ? 'Reorder Notes' : displayedListName}
+        titleLoading={!isReordering && !displayedListName && listNameLoading}
         loading={loading}
         error={error}
         hasContent={tasks.length > 0}

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -99,10 +99,10 @@ export default function ListTasksPage({ setAppBarHeader }) {
   }, [token, listId]);
 
   const fetchListName = useCallback(async () => {
-    setListName('');
     setListNameLoading(true);
 
     if (!listId) {
+      setListName('');
       setListNameLoading(false);
       return;
     }
@@ -112,7 +112,6 @@ export default function ListTasksPage({ setAppBarHeader }) {
       const listData = await response.json();
       setListName(listData?.name ?? '');
     } catch (err) {
-      setListName('');
       setError(err.toString());
     } finally {
       setListNameLoading(false);

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -1,5 +1,5 @@
 // ListTasksPage loads one list's tasks and adds task-specific completion behavior to notepad UI.
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { Box, Button, Checkbox, IconButton, Typography } from '@mui/material';
 import Add from '@mui/icons-material/Add';
@@ -70,6 +70,7 @@ export default function ListTasksPage({ setAppBarHeader }) {
   const [editTask, setEditTask] = useState('');
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
   const displayedListName = location.state?.listName || listName;
+  const listNameRequestIdRef = useRef(0);
 
   // Preserve the AppBar's existing board-only behavior; its title is unrelated to the browser tab.
   useLayoutEffect(() => {
@@ -99,6 +100,8 @@ export default function ListTasksPage({ setAppBarHeader }) {
   }, [token, listId]);
 
   const fetchListName = useCallback(async () => {
+    const requestId = listNameRequestIdRef.current + 1;
+    listNameRequestIdRef.current = requestId;
     setListNameLoading(true);
 
     if (!listId) {
@@ -110,10 +113,13 @@ export default function ListTasksPage({ setAppBarHeader }) {
       const response = await fetchListApi(listId, token);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const listData = await response.json();
+      if (requestId !== listNameRequestIdRef.current) return;
       setListName(listData?.name ?? '');
     } catch (err) {
+      if (requestId !== listNameRequestIdRef.current) return;
       setError(err.toString());
     } finally {
+      if (requestId !== listNameRequestIdRef.current) return;
       setListNameLoading(false);
     }
   }, [listId, token]);

--- a/frontend/src/pages/lists/ListTasksPage.test.js
+++ b/frontend/src/pages/lists/ListTasksPage.test.js
@@ -162,6 +162,56 @@ describe('ListTasksPage', () => {
     expect(await screen.findByRole('heading', { name: 'List 6' })).toBeInTheDocument();
   });
 
+  test('when list title responses resolve out of order, it ignores stale titles', async () => {
+    const { rerender } = await renderNotes();
+
+    mockUseParams.mockReturnValue({ boardId: '1', listId: '6' });
+    fetchNotesApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 103, note: 'test_note_03', status: 'Not Started' }],
+    });
+    const staleList = createDeferred();
+    fetchListApi.mockReturnValueOnce(staleList.promise);
+
+    rerender(
+      <>
+        <ListTasksPage setAppBarHeader={jest.fn()} />
+        <LocationDisplay />
+      </>,
+    );
+
+    expect(await screen.findByText('test_note_03')).toBeInTheDocument();
+
+    mockUseParams.mockReturnValue({ boardId: '1', listId: '7' });
+    fetchNotesApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 104, note: 'test_note_04', status: 'Not Started' }],
+    });
+    const currentList = createDeferred();
+    fetchListApi.mockReturnValueOnce(currentList.promise);
+
+    rerender(
+      <>
+        <ListTasksPage setAppBarHeader={jest.fn()} />
+        <LocationDisplay />
+      </>,
+    );
+
+    expect(await screen.findByText('test_note_04')).toBeInTheDocument();
+
+    await act(async () => {
+      currentList.resolve({ ok: true, json: async () => ({ name: 'List 7' }) });
+    });
+    expect(await screen.findByRole('heading', { name: 'List 7' })).toBeInTheDocument();
+
+    await act(async () => {
+      staleList.resolve({ ok: true, json: async () => ({ name: 'List 6' }) });
+    });
+
+    expect(screen.getByRole('heading', { name: 'List 7' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'List 6' })).not.toBeInTheDocument();
+  });
+
   test('when the fetch fails, it shows an error message', async () => {
     fetchNotesApi.mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
 

--- a/frontend/src/pages/lists/ListTasksPage.test.js
+++ b/frontend/src/pages/lists/ListTasksPage.test.js
@@ -84,7 +84,7 @@ describe('ListTasksPage', () => {
     });
   });
 
-  test('when the page loads, it shows a loading state', async () => {
+  test('when the page loads, it shows skeleton placeholders', async () => {
     const deferred = createDeferred();
     fetchNotesApi.mockReturnValueOnce(deferred.promise);
 
@@ -92,7 +92,8 @@ describe('ListTasksPage', () => {
       routeEntries: ['/board/1/list/5'],
     });
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /loading content/i })).toBeInTheDocument();
+    expect(screen.getByTestId('notepad-loading-skeleton')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^notes$/i })).not.toBeInTheDocument();
 
     deferred.resolve({ ok: true, json: async () => [] });

--- a/frontend/src/pages/lists/ListTasksPage.test.js
+++ b/frontend/src/pages/lists/ListTasksPage.test.js
@@ -115,6 +115,26 @@ describe('ListTasksPage', () => {
     expect(screen.getByRole('checkbox', { name: /mark test_note_02 complete/i })).toBeChecked();
   });
 
+  test('when notes load before the list title, it keeps the title skeleton until the title is ready', async () => {
+    const deferredList = createDeferred();
+    fetchListApi.mockReturnValueOnce(deferredList.promise);
+
+    renderWithProviders(<ListTasksPage setAppBarHeader={jest.fn()} />, {
+      routeEntries: ['/board/1/list/5'],
+    });
+
+    expect(await screen.findByText('test_note_01')).toBeInTheDocument();
+    expect(screen.getByText('test_note_02')).toBeInTheDocument();
+    expect(screen.getByTestId('notepad-title-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'List 5' })).not.toBeInTheDocument();
+
+    deferredList.resolve({ ok: true, json: async () => ({ name: 'List 5' }) });
+
+    expect(await screen.findByRole('heading', { name: 'List 5' })).toBeInTheDocument();
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByText('test_note_01')).toBeInTheDocument();
+  });
+
   test('when the fetch fails, it shows an error message', async () => {
     fetchNotesApi.mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
 

--- a/frontend/src/pages/lists/ListTasksPage.test.js
+++ b/frontend/src/pages/lists/ListTasksPage.test.js
@@ -135,6 +135,33 @@ describe('ListTasksPage', () => {
     expect(screen.getByText('test_note_01')).toBeInTheDocument();
   });
 
+  test('when a later list title is pending, it keeps the previous title instead of showing a skeleton', async () => {
+    const { rerender } = await renderNotes();
+
+    mockUseParams.mockReturnValue({ boardId: '1', listId: '6' });
+    fetchNotesApi.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 103, note: 'test_note_03', status: 'Not Started' }],
+    });
+    const deferredList = createDeferred();
+    fetchListApi.mockReturnValueOnce(deferredList.promise);
+
+    rerender(
+      <>
+        <ListTasksPage setAppBarHeader={jest.fn()} />
+        <LocationDisplay />
+      </>,
+    );
+
+    expect(await screen.findByText('test_note_03')).toBeInTheDocument();
+    expect(screen.queryByTestId('notepad-title-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'List 5' })).toBeInTheDocument();
+
+    deferredList.resolve({ ok: true, json: async () => ({ name: 'List 6' }) });
+
+    expect(await screen.findByRole('heading', { name: 'List 6' })).toBeInTheDocument();
+  });
+
   test('when the fetch fails, it shows an error message', async () => {
     fetchNotesApi.mockResolvedValueOnce({ ok: false, status: 500, json: async () => [] });
 

--- a/frontend/src/test-support/utils.js
+++ b/frontend/src/test-support/utils.js
@@ -16,14 +16,17 @@ const testTheme = createTheme({
 const routerFuture = { v7_startTransition: true, v7_relativeSplatPath: true };
 
 export function renderWithProviders(ui, { routeEntries = ['/'], ...renderOptions } = {}) {
-  return render(
-    <ThemeProvider theme={testTheme}>
-      <MemoryRouter future={routerFuture} initialEntries={routeEntries}>
-        {ui}
-      </MemoryRouter>
-    </ThemeProvider>,
-    renderOptions,
-  );
+  function Providers({ children }) {
+    return (
+      <ThemeProvider theme={testTheme}>
+        <MemoryRouter future={routerFuture} initialEntries={routeEntries}>
+          {children}
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+  }
+
+  return render(ui, { wrapper: Providers, ...renderOptions });
 }
 
 export function createDeferred() {

--- a/frontend/src/test-support/utils.js
+++ b/frontend/src/test-support/utils.js
@@ -37,5 +37,6 @@ export function createDeferred() {
 export async function waitForLoadingToFinish() {
   await waitFor(() => {
     expect(document.body.textContent || '').not.toMatch(/loading/i);
+    expect(document.querySelector('[data-testid="notepad-loading-skeleton"]')).toBeNull();
   });
 }


### PR DESCRIPTION
## Summary
- Replace the shared notepad page's plain loading text with layout-matched skeleton rows.
- Keep an accessible loading status while avoiding visible full-page blank states.
- Update board/list loading tests and the shared loading test helper for the new skeleton state.

## Validation
- npm run lint:strict
- npm test -- --watchAll=false --runInBand
- python -m ruff check backend
- python backend/manage.py test (reported 0 tests from repo root)
- python manage.py test authentication notes notifications --verbosity 2 (hung before output and timed out)

Closes #561


- Closes #581

