### PR TITLE
Prevent notepad loading shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
 ### Fixed
 - Reserved the notepad page title height while board and list titles are loading so existing rows do not shift when the title resolves.
+- Kept the current notepad page visible while the next board or list route loads, avoiding full-page loading flashes during navigation.
 ### Changed
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.
 - Dependabot pull requests now request AI reviews only on failed gates: Lint Eastwood for lint/test failures and RoboCop for CodeQL, vulnerability, or malware failures, while Obi-Wan Code-nobi remains skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 ## 2026-07-12
 ### Added
 - Added shared AI review actions that collect each persona's prior native PR reviews and publish deduplicated native reviews.
+### Fixed
+- Reserved the notepad page title height while board and list titles are loading so existing rows do not shift when the title resolves.
 ### Changed
 - AI review personas now receive prior-review context, use concise Markdown body sections with clearer line breaks and restrained section-heading emojis, and apply more recognizable prompt-guided persona voice.
 - Dependabot pull requests now request AI reviews only on failed gates: Lint Eastwood for lint/test failures and RoboCop for CodeQL, vulnerability, or malware failures, while Obi-Wan Code-nobi remains skipped.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -48,10 +48,7 @@ function NotepadRoutes({ setAppBarHeader }) {
         return slots;
       }
 
-      return [
-        activeSlot,
-        { signature: currentSignature, location, active: false },
-      ];
+      return [activeSlot, { signature: currentSignature, location, active: false }];
     });
   }, [currentSignature, location]);
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import './App.css';
-import React, { useState } from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import React, { useCallback, useEffect, useState } from 'react';
+import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 import AuthenticatedRoute from './components/AuthenticatedRoute';
 import Login from './pages/authentication/Login';
 import Register from './pages/authentication/Register';
@@ -13,6 +13,105 @@ import AppSnackbar from './components/AppSnackbar';
 import BoardNavigationDrawer from './components/BoardNavigationDrawer';
 import NavigationBridge from './components/NavigationBridge';
 import BoardHomeRedirect from './components/BoardHomeRedirect';
+
+function getLocationSignature(location) {
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+function isNotepadRoute(pathname) {
+  return pathname === '/' || /^\/board\/[^/]+(?:\/list\/[^/]+)?$/.test(pathname);
+}
+
+function NotepadRoutes({ setAppBarHeader }) {
+  const location = useLocation();
+  const currentSignature = getLocationSignature(location);
+  const [routeSlots, setRouteSlots] = useState([
+    { signature: currentSignature, location, active: true },
+  ]);
+
+  useEffect(() => {
+    setRouteSlots((slots) => {
+      const activeSlot = slots.find((slot) => slot.active) ?? slots[0];
+      const activeIsNotepadRoute = activeSlot && isNotepadRoute(activeSlot.location.pathname);
+      const currentIsNotepadRoute = isNotepadRoute(location.pathname);
+
+      if (!activeSlot || !activeIsNotepadRoute || !currentIsNotepadRoute) {
+        return [{ signature: currentSignature, location, active: true }];
+      }
+
+      if (activeSlot.signature === currentSignature) {
+        return slots;
+      }
+
+      const pendingSlot = slots.find((slot) => slot.signature === currentSignature);
+      if (pendingSlot) {
+        return slots;
+      }
+
+      return [
+        activeSlot,
+        { signature: currentSignature, location, active: false },
+      ];
+    });
+  }, [currentSignature, location]);
+
+  const handlePageReady = useCallback(
+    (readySignature) => {
+      if (readySignature !== currentSignature) return;
+
+      setRouteSlots((slots) => {
+        const readySlot = slots.find((slot) => slot.signature === readySignature);
+        if (!readySlot) return slots;
+
+        return slots
+          .map((slot) => ({ ...slot, active: slot.signature === readySignature }))
+          .filter((slot) => slot.signature === readySignature);
+      });
+    },
+    [currentSignature],
+  );
+
+  return routeSlots.map((slot) => (
+    <div key={slot.signature} hidden={!slot.active}>
+      <Routes location={slot.location}>
+        <Route
+          path="/"
+          element={
+            <AuthenticatedRoute>
+              <BoardHomeRedirect />
+            </AuthenticatedRoute>
+          }
+        />
+
+        <Route
+          path="/board/:boardId"
+          element={
+            <AuthenticatedRoute>
+              <BoardListsPage
+                active={slot.active}
+                onPageReady={() => handlePageReady(slot.signature)}
+                setAppBarHeader={setAppBarHeader}
+              />
+            </AuthenticatedRoute>
+          }
+        />
+
+        <Route
+          path="/board/:boardId/list/:listId"
+          element={
+            <AuthenticatedRoute>
+              <ListTasksPage
+                active={slot.active}
+                onPageReady={() => handlePageReady(slot.signature)}
+                setAppBarHeader={setAppBarHeader}
+              />
+            </AuthenticatedRoute>
+          }
+        />
+      </Routes>
+    </div>
+  ));
+}
 
 function App() {
   // App Bar
@@ -58,34 +157,7 @@ function App() {
           <Route path="/forgot-password" element={<ForgotPassword showSnackbar={showSnackbar} />} />
           <Route path="/reset-password" element={<ResetPassword showSnackbar={showSnackbar} />} />
 
-          <React.Fragment>
-            <Route
-              path="/"
-              element={
-                <AuthenticatedRoute>
-                  <BoardHomeRedirect />
-                </AuthenticatedRoute>
-              }
-            />
-
-            <Route
-              path="/board/:boardId"
-              element={
-                <AuthenticatedRoute>
-                  <BoardListsPage setAppBarHeader={setAppBarHeader} />
-                </AuthenticatedRoute>
-              }
-            />
-
-            <Route
-              path="/board/:boardId/list/:listId"
-              element={
-                <AuthenticatedRoute>
-                  <ListTasksPage setAppBarHeader={setAppBarHeader} />
-                </AuthenticatedRoute>
-              }
-            />
-          </React.Fragment>
+          <Route path="*" element={<NotepadRoutes setAppBarHeader={setAppBarHeader} />} />
         </Routes>
       </Router>
       <AppSnackbar

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,5 +1,5 @@
 import App from './App';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router-dom';
@@ -39,8 +39,36 @@ jest.mock('./pages/authentication/Register', () => () => <div>RegisterPage</div>
 jest.mock('./pages/authentication/ForgotPassword', () => () => <div>ForgotPasswordPage</div>);
 jest.mock('./pages/authentication/ResetPassword', () => () => <div>ResetPasswordPage</div>);
 jest.mock('./components/BoardHomeRedirect', () => () => <div>BoardHomeRedirect</div>);
-jest.mock('./pages/boards/BoardListsPage', () => () => <div>BoardListsPage</div>);
-jest.mock('./pages/lists/ListTasksPage', () => () => <div>ListTasksPage</div>);
+jest.mock('./pages/boards/BoardListsPage', () => {
+  const { useNavigate } = require('react-router-dom');
+
+  return ({ active }) => {
+    const navigate = useNavigate();
+
+    return (
+      <div data-testid={active ? 'active-board-page' : 'hidden-board-page'}>
+        <button type="button" onClick={() => navigate('/board/1/list/2')}>
+          OpenList
+        </button>
+        BoardListsPage
+      </div>
+    );
+  };
+});
+jest.mock('./pages/lists/ListTasksPage', () => {
+  const React = require('react');
+
+  return ({ active, onPageReady }) => {
+    React.useEffect(() => {
+      globalThis.__notoliListPageReady = onPageReady;
+      return () => {
+        delete globalThis.__notoliListPageReady;
+      };
+    }, [onPageReady]);
+
+    return <div data-testid={active ? 'active-list-page' : 'hidden-list-page'}>ListTasksPage</div>;
+  };
+});
 
 const testTheme = createTheme();
 const routerFuture = { v7_startTransition: true, v7_relativeSplatPath: true };
@@ -58,6 +86,7 @@ function renderApp(route) {
 describe('App', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    delete globalThis.__notoliListPageReady;
   });
 
   test('when the route is /login, it renders Login', () => {
@@ -126,5 +155,22 @@ describe('App', () => {
     await userEvent.click(screen.getByRole('button', { name: /toggledrawer/i }));
 
     expect(screen.getByTestId('drawer')).toHaveTextContent('DrawerOpen');
+  });
+
+  test('when a notepad route is loading, it keeps the previous page visible until ready', async () => {
+    sessionStorage.setItem('accessToken', 'token');
+    renderApp('/board/1');
+
+    await userEvent.click(screen.getByRole('button', { name: /openlist/i }));
+
+    expect(screen.getByTestId('active-board-page')).toBeInTheDocument();
+    expect(screen.getByTestId('hidden-list-page')).toBeInTheDocument();
+
+    act(() => {
+      globalThis.__notoliListPageReady();
+    });
+
+    expect(await screen.findByTestId('active-list-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('active-board-page')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/notepadPages/NotepadPageShell.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.js
@@ -51,7 +51,13 @@ export default function NotepadPageShell({
               variant="h4"
               align="center"
               gutterBottom
-              sx={{ fontWeight: 'bold', color: 'var(--secondary-color)' }}
+              data-testid="notepad-page-title"
+              sx={{
+                fontWeight: 'bold',
+                color: 'var(--secondary-color)',
+                lineHeight: 1.235,
+                minHeight: '2.625rem',
+              }}
             >
               {title}
             </Typography>

--- a/frontend/src/components/notepadPages/NotepadPageShell.test.js
+++ b/frontend/src/components/notepadPages/NotepadPageShell.test.js
@@ -42,6 +42,15 @@ describe('NotepadPageShell', () => {
     expect(screen.getByText('Rows go here')).toBeInTheDocument();
   });
 
+  test('when content is loaded while the title is pending, it reserves title height', () => {
+    renderShell({ title: '', loading: true, hasContent: true });
+
+    expect(screen.getByTestId('notepad-page-title')).toHaveStyle({
+      minHeight: '2.625rem',
+    });
+    expect(screen.getByText('Rows go here')).toBeInTheDocument();
+  });
+
   test('when an error exists, it shows the error and hides child content', () => {
     renderShell({ error: 'Error: HTTP 500' });
 

--- a/frontend/src/pages/boards/BoardListsPage.js
+++ b/frontend/src/pages/boards/BoardListsPage.js
@@ -46,7 +46,7 @@ const pageActionButtonSx = {
 
 const rowTitleSx = { fontSize: '1.1rem', textAlign: 'left' };
 
-export default function BoardListsPage({ setAppBarHeader }) {
+export default function BoardListsPage({ active = true, onPageReady = () => {}, setAppBarHeader }) {
   const navigate = useNavigate();
   const { boardId } = useParams();
   const token = sessionStorage.getItem('accessToken');
@@ -64,12 +64,20 @@ export default function BoardListsPage({ setAppBarHeader }) {
   const actionMenuOpen = Boolean(actionMenuAnchorEl);
 
   useLayoutEffect(() => {
+    if (!active) return;
     setAppBarHeader('');
-  }, [setAppBarHeader]);
+  }, [active, setAppBarHeader]);
 
   useEffect(() => {
+    if (!active) return;
     document.title = boardName ? `Notoli - ${boardName}` : 'Notoli';
-  }, [boardName]);
+  }, [active, boardName]);
+
+  useEffect(() => {
+    if (!loading) {
+      onPageReady();
+    }
+  }, [loading, onPageReady]);
 
   const fetchLists = useCallback(async () => {
     setLoading(true);

--- a/frontend/src/pages/lists/ListTasksPage.js
+++ b/frontend/src/pages/lists/ListTasksPage.js
@@ -51,7 +51,7 @@ const pageActionButtonSx = {
   color: 'var(--secondary-color)',
 };
 
-export default function ListTasksPage({ setAppBarHeader }) {
+export default function ListTasksPage({ active = true, onPageReady = () => {}, setAppBarHeader }) {
   const { boardId, listId } = useParams();
   const location = useLocation();
   const token = sessionStorage.getItem('accessToken');
@@ -71,15 +71,23 @@ export default function ListTasksPage({ setAppBarHeader }) {
 
   // Preserve the AppBar's existing board-only behavior; its title is unrelated to the browser tab.
   useLayoutEffect(() => {
-    setAppBarHeader(location.state?.boardName ?? '');
-  }, [boardId, location.state?.boardName, setAppBarHeader]);
+    if (!active) return;
+    setAppBarHeader(location.state?.boardName || boardName || '');
+  }, [active, boardId, boardName, location.state?.boardName, setAppBarHeader]);
 
   useEffect(() => {
+    if (!active) return;
     document.title = formatDocumentTitle(
       location.state?.boardName || boardName,
       location.state?.listName || listName,
     );
-  }, [boardName, listName, location.state?.boardName, location.state?.listName]);
+  }, [active, boardName, listName, location.state?.boardName, location.state?.listName]);
+
+  useEffect(() => {
+    if (!loading) {
+      onPageReady();
+    }
+  }, [loading, onPageReady]);
 
   const fetchTasks = useCallback(async () => {
     setLoading(true);
@@ -121,17 +129,21 @@ export default function ListTasksPage({ setAppBarHeader }) {
         const boardData = await response.json();
         if (isActive()) {
           setBoardName(boardData?.name ?? '');
-          setAppBarHeader(boardData?.name ?? '');
+          if (active) {
+            setAppBarHeader(boardData?.name ?? '');
+          }
         }
       } catch (err) {
         if (isActive()) {
           setBoardName('');
-          setAppBarHeader('');
+          if (active) {
+            setAppBarHeader('');
+          }
         }
         setError(err.toString());
       }
     },
-    [boardId, token, setAppBarHeader],
+    [active, boardId, token, setAppBarHeader],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- reserve the notepad title row while board and list titles are still loading
- keep the current notepad page visible while the next board or list route preloads
- prevent hidden preload routes from updating the visible app bar or browser title

## Why
Board and list pages could show a full-page loading state or shift rows during route transitions because the destination route mounted immediately with empty local data. The app now waits to reveal the destination page until its primary rows have loaded.

## Validation
- npm test -- --watchAll=false App.test.js BoardListsPage.test.js ListTasksPage.test.js NotepadPageShell.test.js
- npm run lint -- --quiet
- docker compose down
- docker build -t ghcr.io/vanillaicecube/notoli-backend:latest ./backend
- docker build --build-arg REACT_APP_API_BASE_URL= -t ghcr.io/vanillaicecube/notoli-frontend:latest ./frontend
- docker compose up -d
- docker compose exec -T backend python manage.py migrate
- curl -I http://localhost:3000/
- curl -k -I --resolve notoli.judeandrewalaba.com:443:127.0.0.1 https://notoli.judeandrewalaba.com/

Fixes #581