### PR TITLE
Harden security-alert project reconciliation

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -146,7 +146,7 @@ Dependabot configuration:
   - npm (`/frontend`)
   - pip (`/backend`)
   - GitHub Actions (`/`)
-  - Docker (`/`, `/backend`, `/frontend`)
+  - Docker (`/backend`, `/frontend`)
 
 Auto-merge behavior:
 - Dependabot PRs go through CI (`ci-orchestrator.yml`), and if all gates pass, `ci-auto-merge.yml` can enable auto-merge.

--- a/.github/actions/publish-ai-review/publish-ai-review.test.js
+++ b/.github/actions/publish-ai-review/publish-ai-review.test.js
@@ -530,5 +530,8 @@ test("keeps the visually inspectable Markdown examples synchronized", () => {
   ].join("\n");
   const fixturePath = path.join(__dirname, "review-output-examples.md");
 
-  assert.equal(fs.readFileSync(fixturePath, "utf8"), examples);
+  assert.equal(
+    fs.readFileSync(fixturePath, "utf8").replace(/\r\n/g, "\n"),
+    examples,
+  );
 });

--- a/.github/actions/security-alerts/sync-security-alerts.js
+++ b/.github/actions/security-alerts/sync-security-alerts.js
@@ -249,6 +249,23 @@ async function findProjectItemId(github, projectId, contentId) {
   return null;
 }
 
+const projectItemRetryDelays = [0, 250, 500, 1000, 2000, 4000];
+
+function isProjectItemAlreadyExistsError(error) {
+  return error?.errors?.some(
+    (entry) => entry.message === "Content already exists in this project",
+  );
+}
+
+async function findProjectItemIdEventually(github, projectId, contentId) {
+  for (const delay of projectItemRetryDelays) {
+    if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+    const itemId = await findProjectItemId(github, projectId, contentId);
+    if (itemId) return itemId;
+  }
+  return null;
+}
+
 async function ensureProjectItem(github, projectId, projectState, issue) {
   const existingItemId = projectState.itemsByContentId.get(issue.node_id);
   if (existingItemId) return { itemId: existingItemId, added: false };
@@ -262,7 +279,12 @@ async function ensureProjectItem(github, projectId, projectState, issue) {
     projectState.itemsByContentId.set(issue.node_id, itemId);
     return { itemId, added: true };
   } catch (error) {
-    const itemId = await findProjectItemId(github, projectId, issue.node_id);
+    if (!isProjectItemAlreadyExistsError(error)) throw error;
+    const itemId = await findProjectItemIdEventually(
+      github,
+      projectId,
+      issue.node_id,
+    );
     if (!itemId) throw error;
     projectState.itemsByContentId.set(issue.node_id, itemId);
     return { itemId, added: false };

--- a/.github/actions/security-alerts/sync-security-alerts.js
+++ b/.github/actions/security-alerts/sync-security-alerts.js
@@ -252,9 +252,14 @@ async function findProjectItemId(github, projectId, contentId) {
 const projectItemRetryDelays = [0, 250, 500, 1000, 2000, 4000];
 
 function isProjectItemAlreadyExistsError(error) {
-  return error?.errors?.some(
-    (entry) => entry.message === "Content already exists in this project",
-  );
+  return error?.errors?.some((entry) => {
+    const message = String(entry.message ?? "").trim();
+    const typeMatches = !entry.type || entry.type === "UNPROCESSABLE";
+    return (
+      typeMatches &&
+      /^Content already exists in (?:this|the) project\.?$/i.test(message)
+    );
+  });
 }
 
 async function findProjectItemIdEventually(github, projectId, contentId) {

--- a/.github/actions/security-alerts/sync-security-alerts.test.js
+++ b/.github/actions/security-alerts/sync-security-alerts.test.js
@@ -401,6 +401,7 @@ test("synchronization preserves canonical project fields and completes supersede
 test("synchronization sends issue creation, labels, and assignment only through RoboCop", async () => {
   const issueCalls = [];
   const projectCalls = [];
+  let projectItemQueryCount = 0;
   const createdIssue = {
     number: 20,
     node_id: "ISSUE_20",
@@ -477,17 +478,23 @@ test("synchronization sends issue creation, labels, and assignment only through 
         };
       }
       if (query.includes("items(first: 100")) {
+        projectItemQueryCount += 1;
         return {
           node: {
             items: {
-              nodes: [],
+              nodes:
+                projectItemQueryCount >= 3
+                  ? [{ id: "ITEM_20", content: { id: "ISSUE_20" } }]
+                  : [],
               pageInfo: { hasNextPage: false, endCursor: null },
             },
           },
         };
       }
       if (query.includes("addProjectV2ItemById")) {
-        return { addProjectV2ItemById: { item: { id: "ITEM_20" } } };
+        throw {
+          errors: [{ message: "Content already exists in this project" }],
+        };
       }
       if (query.includes("updateProjectV2ItemFieldValue")) {
         return { updateProjectV2ItemFieldValue: { projectV2Item: {} } };

--- a/.github/actions/security-alerts/sync-security-alerts.test.js
+++ b/.github/actions/security-alerts/sync-security-alerts.test.js
@@ -493,7 +493,12 @@ test("synchronization sends issue creation, labels, and assignment only through 
       }
       if (query.includes("addProjectV2ItemById")) {
         throw {
-          errors: [{ message: "Content already exists in this project" }],
+          errors: [
+            {
+              type: "UNPROCESSABLE",
+              message: "Content already exists in this project",
+            },
+          ],
         };
       }
       if (query.includes("updateProjectV2ItemFieldValue")) {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,6 @@ updates:
       time: "00:00"
 
   - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "00:00"
-
-  - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
       interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## 2026-08-22
+### Fixed
+- Made security-alert Project v2 reconciliation tolerate eventual consistency
+  after GitHub reports that an issue already exists on the project board.
+- Removed the invalid root-level Docker Dependabot scan; Docker checks remain
+  configured for the backend and frontend directories.
+
 ## 2026-07-25
 ### Added
 - Added regression coverage proving RoboCop performs every security-alert issue mutation while the personal credential is limited to Project v2 operations.


### PR DESCRIPTION
## Summary
- Make Project v2 reconciliation retry after GitHub reports `Content already exists in this project` while the item is still becoming visible.
- Add regression coverage for duplicate project-item creation and delayed item visibility.
- Remove the invalid root-level Docker Dependabot entry; retain `/backend` and `/frontend` scans.
- Update workflow documentation and changelog, plus make the fixture comparison line-ending neutral on Windows.

## Verification
- `git diff --check` passed.
- Repository automation tests passed: 25/25.
- PR checks: 16 successful, 5 correctly skipped.
- Alert workflows passed on the implementation branch:
  - [CodeQL](https://github.com/VanillaIceCube/Notoli/actions/runs/32608139811)
  - [Vulnerability](https://github.com/VanillaIceCube/Notoli/actions/runs/32608141033)
  - [Malware](https://github.com/VanillaIceCube/Notoli/actions/runs/32608141964)

Closes #705