### PR TITLE
Fix Dependabot security gate reliability

### DIFF
--- a/.github/README-WORKFLOWS.md
+++ b/.github/README-WORKFLOWS.md
@@ -35,6 +35,7 @@ What it does:
   - Emits a vulnerability report output for RoboCop instead of posting a standalone PR comment.
 - Runs the reusable malware gate: [`.github/workflows/gate-malware.yml`](workflows/gate-malware.yml)
   - Uses the local [npm malware review action](actions/review-npm-malware/action.yml) to compare changed `frontend/package-lock.json` packages against GitHub's npm malware advisories.
+  - Follows GitHub's cursor-based advisory pagination and applies a per-request timeout so the gate terminates reliably as the advisory feed grows.
   - Emits a malware report output for RoboCop and fails when a changed package/version matches a known malware advisory.
 - For trusted same-repository, non-Dependabot PRs, runs [`.github/workflows/review-code.yml`](workflows/review-code.yml)
   - Runs Obi-Wan Code-nobi, the AI Code Reviewer, for general implementation review
@@ -153,4 +154,4 @@ Auto-merge behavior:
 - Dependabot PRs do not receive secret-dependent AI reviews. Their independent lint, test, CodeQL, vulnerability, and malware gates provide failure details and block auto-merge when any gate fails.
 - Auto-merge is restricted to patch/minor updates.
 - If a security alert is present, the workflow requires CVSS <= 6.9.
-- The workflow uses `dependabot/fetch-metadata@v2` and can optionally use `DEPENDABOT_PAT` for metadata/alert lookup.
+- The workflow uses `dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (`v3.1.0`) and can optionally use `DEPENDABOT_PAT` for metadata/alert lookup.

--- a/.github/actions/review-npm-malware/action.yml
+++ b/.github/actions/review-npm-malware/action.yml
@@ -84,24 +84,27 @@ runs:
 
         async function fetchMalwareAdvisories() {
           const advisories = [];
-          for (let page = 1; ; page += 1) {
-            const url = new URL('https://api.github.com/advisories');
-            url.searchParams.set('ecosystem', 'npm');
-            url.searchParams.set('type', 'malware');
-            url.searchParams.set('per_page', '100');
-            url.searchParams.set('page', String(page));
-            const response = await fetch(url, {
+          let nextUrl = new URL('https://api.github.com/advisories');
+          nextUrl.searchParams.set('ecosystem', 'npm');
+          nextUrl.searchParams.set('type', 'malware');
+          nextUrl.searchParams.set('per_page', '100');
+          while (nextUrl) {
+            const response = await fetch(nextUrl, {
               headers: {
                 Accept: 'application/vnd.github+json',
                 Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
                 'X-GitHub-Api-Version': '2022-11-28',
               },
+              signal: AbortSignal.timeout(30_000),
             });
             if (!response.ok) throw new Error(`GitHub Advisory API returned ${response.status}`);
             const results = await response.json();
             advisories.push(...results);
-            if (results.length < 100) return advisories;
+            const link = response.headers.get('link') || '';
+            const match = link.match(/<([^>]+)>;\s*rel="next"/);
+            nextUrl = match ? new URL(match[1]) : null;
           }
+          return advisories;
         }
 
         function findingsFor(packages, advisories) {

--- a/.github/workflows/ci-auto-merge.yml
+++ b/.github/workflows/ci-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.DEPENDABOT_PAT || secrets.GITHUB_TOKEN }}
           alert-lookup: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented in this file.
   after GitHub reports that an issue already exists on the project board.
 - Removed the invalid root-level Docker Dependabot scan; Docker checks remain
   configured for the backend and frontend directories.
+- Followed GitHub Advisory API cursor pagination in the npm malware gate so Dependabot npm checks no longer loop over the first page until the job timeout.
+- Pinned `dependabot/fetch-metadata` to an immutable `v3.1.0` commit in the auto-merge workflow so CodeQL no longer reports an unpinned third-party action.
 
 ## 2026-07-25
 ### Added


### PR DESCRIPTION
## What changed\n- Follow GitHub Advisory API cursor pagination in the npm malware gate.\n- Bound each advisory API request with a 30-second timeout.\n- Pin dependabot/fetch-metadata v3.1.0 to an immutable commit to satisfy CodeQL.\n- Document the gate behavior and changelog entry.\n\nThis unblocks the open Dependabot PRs whose malware checks are timing out and addresses the actionable CodeQL comment on #594.